### PR TITLE
consolidate led by sensor

### DIFF
--- a/MIDAS/src/errors.cpp
+++ b/MIDAS/src/errors.cpp
@@ -14,7 +14,7 @@
  * BLUE, ORANGE => GPS error
  * BLUE, RED => CONTINUITY error
  * GREEN, ORANGE => BNO error
- * GREEN, RED => 
+ * GREEN, RED => EMMC error
  * ORANGE, RED => 
  * BLUE, GREEN, ORANGE => 
  * BLUE, GREEN, RED => 
@@ -85,6 +85,14 @@ void update_error_LED(ErrorCode error) {
             gpioDigitalWrite(green_led, HIGH);
             gpioDigitalWrite(orange_led, HIGH);
             gpioDigitalWrite(red_led, LOW);
+            break;
+        case EmmcPinsAreWrong:
+        case EmmcCouldNotBegin:
+        case EmmcCouldNotOpenFile:
+            gpioDigitalWrite(blue_led, LOW);
+            gpioDigitalWrite(green_led, HIGH);
+            gpioDigitalWrite(orange_led, LOW);
+            gpioDigitalWrite(red_led, HIGH);
             break;
         default:
             gpioDigitalWrite(blue_led, HIGH);

--- a/MIDAS/src/errors.cpp
+++ b/MIDAS/src/errors.cpp
@@ -6,21 +6,21 @@
  * The combination of all 4 lights will tell you what the error is
  *
  * NONE => Nothing is wrong
- * BLUE => LOW G could not init
+ * BLUE => LowG Error
  * GREEN => Could not begin SD card
- * ORANGE => Could not set LOW G range
- * RED => LOW G Output Data Rate Low Pass Filter could not be set
- * BLUE, GREEN => HIGH G could not init
- * BLUE, ORANGE => HIGH G could not update Data Rate
- * BLUE, RED => MAGNETOMETER could not be init
- * GREEN, ORANGE => GYRO could not init
- * GREEN, RED => GPS could not init
- * ORANGE, RED => CONTINUITY could not init
- * BLUE, GREEN, ORANGE => BNO could not connect
- * BLUE, GREEN, RED => BNO could not init
+ * ORANGE => HighG error
+ * RED => MAGNETOMETER error
+ * BLUE, GREEN => GYRO error
+ * BLUE, ORANGE => GPS error
+ * BLUE, RED => CONTINUITY error
+ * GREEN, ORANGE => BNO error
+ * GREEN, RED => 
+ * ORANGE, RED => 
+ * BLUE, GREEN, ORANGE => 
+ * BLUE, GREEN, RED => 
  * BLUE, ORANGE, RED => 
  * GREEN, ORANGE, RED =>
- * BLUE, GREEN, ORANGE, RED => Default, somehow the function was called with a different error, should never happen
+ * BLUE, GREEN, ORANGE, RED => Default, means something went very wrong
  */
 
 #define TURN_ONE_RED_LED 
@@ -35,6 +35,8 @@ GpioAddress red_led(GPIO_EXPANDER_2, 016);
 void update_error_LED(ErrorCode error) {
     switch (error) {
         case LowGCouldNotBeInitialized:
+        case LowGRangeCouldNotBeSet:
+        case LowGODRLPFCouldNotBeSet:
             gpioDigitalWrite(blue_led, HIGH);
             gpioDigitalWrite(green_led, LOW);
             gpioDigitalWrite(orange_led, LOW);
@@ -46,66 +48,44 @@ void update_error_LED(ErrorCode error) {
             gpioDigitalWrite(orange_led, LOW);
             gpioDigitalWrite(red_led, LOW);
             break;
-        case LowGRangeCouldNotBeSet:
-            gpioDigitalWrite(blue_led, LOW);
-            gpioDigitalWrite(green_led, LOW);
-            gpioDigitalWrite(orange_led, HIGH);
-            gpioDigitalWrite(red_led, LOW);
-            break;
-        case LowGODRLPFCouldNotBeSet:
-            gpioDigitalWrite(blue_led, LOW);
-            gpioDigitalWrite(green_led, LOW);
-            gpioDigitalWrite(orange_led, LOW);
-            gpioDigitalWrite(red_led, HIGH);
-            break;
         case HighGCouldNotBeInitialized:
-            gpioDigitalWrite(blue_led, HIGH);
-            gpioDigitalWrite(green_led, HIGH);
-            gpioDigitalWrite(orange_led, LOW);
-            gpioDigitalWrite(red_led, LOW);
-            break;   
         case HighGCoulNotUpdateDataRate:
-            gpioDigitalWrite(blue_led, HIGH);
+            gpioDigitalWrite(blue_led, LOW);
             gpioDigitalWrite(green_led, LOW);
             gpioDigitalWrite(orange_led, HIGH);
             gpioDigitalWrite(red_led, LOW);
             break;
         case MagnetometerCoultNotBeInitialized:
-            gpioDigitalWrite(blue_led, HIGH);
+            gpioDigitalWrite(blue_led, LOW);
             gpioDigitalWrite(green_led, LOW);
             gpioDigitalWrite(orange_led, LOW);
             gpioDigitalWrite(red_led, HIGH);
             break;
         case GyroCouldNotBeInitialized:
-            gpioDigitalWrite(blue_led, LOW);
-            gpioDigitalWrite(green_led, HIGH);
-            gpioDigitalWrite(orange_led, HIGH);
-            gpioDigitalWrite(red_led, LOW);
-            break; 
-        case GPSCouldNotBeInitialized:
-            gpioDigitalWrite(blue_led, LOW);
+            gpioDigitalWrite(blue_led, HIGH);
             gpioDigitalWrite(green_led, HIGH);
             gpioDigitalWrite(orange_led, LOW);
-            gpioDigitalWrite(red_led, HIGH);
-            break; 
-        case ContinuityCouldNotBeInitialized:
-            gpioDigitalWrite(blue_led, LOW);
+            gpioDigitalWrite(red_led, LOW);
+            break;   
+        case GPSCouldNotBeInitialized:
+            gpioDigitalWrite(blue_led, HIGH);
             gpioDigitalWrite(green_led, LOW);
             gpioDigitalWrite(orange_led, HIGH);
-            gpioDigitalWrite(red_led, HIGH);
-            break; 
-        case CannotConnectBNO:
+            gpioDigitalWrite(red_led, LOW);
+            break;
+        case ContinuityCouldNotBeInitialized:
             gpioDigitalWrite(blue_led, HIGH);
+            gpioDigitalWrite(green_led, LOW);
+            gpioDigitalWrite(orange_led, LOW);
+            gpioDigitalWrite(red_led, HIGH);
+            break;
+        case CannotConnectBNO:
+        case CannotInitBNO:
+            gpioDigitalWrite(blue_led, LOW);
             gpioDigitalWrite(green_led, HIGH);
             gpioDigitalWrite(orange_led, HIGH);
             gpioDigitalWrite(red_led, LOW);
-            break; 
-        case CannotInitBNO:
-            gpioDigitalWrite(blue_led, HIGH);
-            gpioDigitalWrite(green_led, HIGH);
-            gpioDigitalWrite(orange_led, LOW);
-            gpioDigitalWrite(red_led, HIGH);
-            break; 
+            break;
         default:
             gpioDigitalWrite(blue_led, HIGH);
             gpioDigitalWrite(green_led, HIGH);

--- a/MIDAS/src/errors.cpp
+++ b/MIDAS/src/errors.cpp
@@ -15,7 +15,7 @@
  * BLUE, RED => CONTINUITY error
  * GREEN, ORANGE => BNO error
  * GREEN, RED => EMMC error
- * ORANGE, RED => 
+ * ORANGE, RED => PYRO error
  * BLUE, GREEN, ORANGE => 
  * BLUE, GREEN, RED => 
  * BLUE, ORANGE, RED => 
@@ -42,6 +42,11 @@ void update_error_LED(ErrorCode error) {
             gpioDigitalWrite(orange_led, LOW);
             gpioDigitalWrite(red_led, LOW);
             break;
+        case PyroGPIOCouldNotBeInitialized:
+            gpioDigitalWrite(blue_led, LOW);
+            gpioDigitalWrite(green_led, LOW);
+            gpioDigitalWrite(orange_led, HIGH);
+            gpioDigitalWrite(red_led, HIGH);
         case SDBeginFailed:
             gpioDigitalWrite(blue_led, LOW);
             gpioDigitalWrite(green_led, HIGH);

--- a/MIDAS/src/errors.h
+++ b/MIDAS/src/errors.h
@@ -16,7 +16,8 @@ enum ErrorCode {
     CannotInitBNO,
     EmmcPinsAreWrong,
     EmmcCouldNotBegin,
-    EmmcCouldNotOpenFile
+    EmmcCouldNotOpenFile,
+    PyroGPIOCouldNotBeInitialized
 };
 
 void update_error_LED(ErrorCode error);

--- a/MIDAS/src/errors.h
+++ b/MIDAS/src/errors.h
@@ -13,7 +13,10 @@ enum ErrorCode {
     GPSCouldNotBeInitialized,
     ContinuityCouldNotBeInitialized,
     CannotConnectBNO,
-    CannotInitBNO
+    CannotInitBNO,
+    EmmcPinsAreWrong,
+    EmmcCouldNotBegin,
+    EmmcCouldNotOpenFile
 };
 
 void update_error_LED(ErrorCode error);


### PR DESCRIPTION
Consolidated LEDs by the sensor they come from. This is meant to open up more ways to display error codes, since we are almost running out. I have not yet implemented blinking support but that is somewhat trivial to do, we can just steal code from tars.

I'm making the pr as a way to keep this branch visible and alive, its not meant to be merged in, at least right now. Whenever a new error is added, this branch should be updated.