### PR TITLE
MIDAS commanding from feather

### DIFF
--- a/MIDAS/src/hardware/telemetry_backend.h
+++ b/MIDAS/src/hardware/telemetry_backend.h
@@ -71,11 +71,11 @@ public:
         for(int i = 1; i < wait_milliseconds; i++){
             THREAD_SLEEP(1);
             if(digitalRead(rf95._interruptPin)){
+                rf95.handleInterrupt();
                 break;
             }
         }
 
-        rf95.handleInterrupt();
         if (rf95.available() && rf95.recv((uint8_t*) command, &len)) {
             if (sizeof(T) == len) {
                 return true;

--- a/MIDAS/src/systems.cpp
+++ b/MIDAS/src/systems.cpp
@@ -159,6 +159,10 @@ DECLARE_THREAD(telemetry, RocketSystems* arg) {
             TelemetryCommand command;
             if (arg->tlm.receive(&command, 1000)) {
                 // handle command
+                if (command.command == CommandType::RESET_KF && command.do_KF_reset) {
+                    yessir.initialize();
+                    Serial.println("Reset KF");
+                }
                 Serial.println(command.callsign);
             }
         } else {

--- a/MIDAS/src/systems.cpp
+++ b/MIDAS/src/systems.cpp
@@ -154,7 +154,16 @@ DECLARE_THREAD(telemetry, RocketSystems* arg) {
     while (true) {
         arg->tlm.transmit(arg->rocket_data, arg->led);
 
-        THREAD_SLEEP(1);
+        FSMState current_state = arg->rocket_data.fsm_state.getRecentUnsync();
+        if (current_state == FSMState(STATE_IDLE)) {
+            TelemetryCommand command;
+            if (arg->tlm.receive(&command, 1000)) {
+                // handle command
+                Serial.println(command.callsign);
+            }
+        } else {
+            THREAD_SLEEP(1);
+        }
     }
 }
 

--- a/MIDAS/src/systems.cpp
+++ b/MIDAS/src/systems.cpp
@@ -1,4 +1,4 @@
-#include "systems.h"
+    #include "systems.h"
 
 #include "hal.h"
 #include "gnc/yessir.h"
@@ -157,7 +157,7 @@ DECLARE_THREAD(telemetry, RocketSystems* arg) {
         FSMState current_state = arg->rocket_data.fsm_state.getRecentUnsync();
         if (current_state == FSMState(STATE_IDLE)) {
             TelemetryCommand command;
-            if (arg->tlm.receive(&command, 1000)) {
+            if (arg->tlm.receive(&command, 2000)) {
                 // handle command
                 if (command.command == CommandType::RESET_KF && command.do_KF_reset) {
                     yessir.initialize();

--- a/MIDAS/src/systems.h
+++ b/MIDAS/src/systems.h
@@ -10,6 +10,7 @@
 #include "led.h"
 #include "telemetry.h"
 #include "finite-state-machines/fsm.h"
+#include "telemetry_received.h"
 
 #if defined(SILSIM)
 #include "silsim/emulated_sensors.h"

--- a/MIDAS/src/telemetry.cpp
+++ b/MIDAS/src/telemetry.cpp
@@ -1,6 +1,7 @@
 #include <cmath>
 
 #include "telemetry.h"
+#include "telemetry_received.h"
 
 
 /**
@@ -57,6 +58,10 @@ void Telemetry::transmit(RocketData& rocket_data, LEDController& led) {
     TelemetryPacket packet = makePacket(rocket_data);
     led.toggle(LED::BLUE);
     backend.send(packet);
+}
+
+bool Telemetry::receive(TelemetryCommand* command, int wait_milliseconds) {    
+    return backend.read(command, wait_milliseconds);
 }
 
 /**

--- a/MIDAS/src/telemetry.h
+++ b/MIDAS/src/telemetry.h
@@ -4,6 +4,7 @@
 #include "rocket_state.h"
 #include "errors.h"
 #include "led.h"
+#include "telemetry_received.h"
 
 #if defined(SILSIM)
 #include "silsim/emulated_telemetry.h"
@@ -25,6 +26,7 @@ public:
     ErrorCode __attribute__((warn_unused_result)) init();
 
     void transmit(RocketData& rocket_data, LEDController& led);
+    bool receive(TelemetryCommand *write, int wait_milliseconds);
 private:
     TelemetryPacket makePacket(RocketData& data);
 

--- a/MIDAS/src/telemetry_received.h
+++ b/MIDAS/src/telemetry_received.h
@@ -16,6 +16,7 @@ struct TelemetryCommand {
         char callsign[8];
         float freq;
         bool do_abort;
+        bool do_KF_reset;
     };
     std::array<char, 6> verify = {{'A', 'Y', 'B', 'E', 'R', 'K'}};
 };

--- a/MIDAS/src/telemetry_received.h
+++ b/MIDAS/src/telemetry_received.h
@@ -1,0 +1,21 @@
+#pragma once
+#include <array>
+
+enum class CommandType { SET_FREQ, SET_CALLSIGN, ABORT, TEST_FLAP, EMPTY , RESET_KF };
+// Commands transmitted from ground station to rocket
+
+/**
+ * @struct TelemetryCommand
+ * 
+ * @brief format of the packet that telemetry receives
+*/
+struct TelemetryCommand {
+    CommandType command;
+    int id;
+    union {
+        char callsign[8];
+        float freq;
+        bool do_abort;
+    };
+    std::array<char, 6> verify = {{'A', 'Y', 'B', 'E', 'R', 'K'}};
+};

--- a/ground/lib/RadioHead/RH_RF95.cpp
+++ b/ground/lib/RadioHead/RH_RF95.cpp
@@ -100,8 +100,6 @@ bool RH_RF95::setupInterruptHandler()
 {
     //were using polling so no interrupts should be setup
     pinMode(_interruptPin, INPUT);
-    return true;
-
 
     // For some subclasses (eg RH_ABZ)  we dont want to set up interrupt
     int interruptNumber = NOT_AN_INTERRUPT;


### PR DESCRIPTION
If on launchpad, each time it transmits data, MIDAS will wait 1000 milliseconds for an interrupt to receive a TelemetryCommand struct. It should then interpret this command struct to perform different operations based on the values in the struct (e.g. change frequency, reset KF, set callsign, etc).