### PR TITLE
Fixing pyro firing conditions & pyro alignment

### DIFF
--- a/MIDAS/src/hardware/pins.h
+++ b/MIDAS/src/hardware/pins.h
@@ -54,15 +54,11 @@
 #define SD_D0 6
 
 // pyro pins
-#define PYRO_GLOBAL_ARM_PIN GpioAddress(0, 07)
-#define PYROA_ARM_PIN GpioAddress(0, 016)
-#define PYROA_FIRE_PIN GpioAddress(0, 017)
-#define PYROB_ARM_PIN GpioAddress(0, 014)
-#define PYROB_FIRE_PIN GpioAddress(0, 015)
-#define PYROC_ARM_PIN GpioAddress(0, 010)
-#define PYROC_FIRE_PIN GpioAddress(0, 011)
-#define PYROD_ARM_PIN GpioAddress(0, 012)
-#define PYROD_FIRE_PIN GpioAddress(0, 013)
+#define PYRO_GLOBAL_ARM_PIN GpioAddress(0, 05)
+#define PYROA_FIRE_PIN GpioAddress(0, 04)
+#define PYROB_FIRE_PIN GpioAddress(0, 03)
+#define PYROC_FIRE_PIN GpioAddress(0, 01)
+#define PYROD_FIRE_PIN GpioAddress(0, 00)
 
 // Continuity Pins
 #define SENSE_PYRO 1

--- a/MIDAS/src/sensor_data.h
+++ b/MIDAS/src/sensor_data.h
@@ -231,21 +231,18 @@ struct KalmanData {
 };
 
 /**
- * @struct PyroChannel
- * 
- * @brief data about a specific pyro channel
-*/
-struct PyroChannel {
-    bool is_armed = false;
-    bool is_firing = false;
-};
-
-/**
  * @struct PyroState
  * 
  * @brief data regarding all pyro channels
 */
 struct PyroState {
     bool is_global_armed = false;
-    PyroChannel channels[4];
+    bool channel_firing[4];
+    /**
+     * By convention, the pyro states are as follows:
+     * [0] PYRO A / APOGEE
+     * [1] PYRO B / MAIN
+     * [2] PYRO C / MOTOR
+     * [3] PYRO D / AUX
+     */
 };


### PR DESCRIPTION
Aligns PyroState to the following channels:
[0] PYRO A / APOGEE
[1] PYRO B / MAIN
[2] PYRO C / MOTOR
[3] PYRO D / AUX

Additionally adds orientation sensing for pyro fire, and edits all necessary pyro deployment states.