### PR TITLE
More flexible vmux switch interface, + 80 sec vmux fallback

### DIFF
--- a/MIDAS/src/b2b_interface.h
+++ b/MIDAS/src/b2b_interface.h
@@ -17,6 +17,9 @@
 #define CAM_1 0
 #define CAM_2 1
 
+#define SIDE_CAMERA CAM_1
+#define BULKHEAD_CAMERA CAM_2
+
 
 enum class CameraCommand {
     CAMERA1_OFF = 0,

--- a/MIDAS/src/systems.cpp
+++ b/MIDAS/src/systems.cpp
@@ -325,8 +325,10 @@ void handle_tlm_command(TelemetryCommand& command, RocketSystems* arg, FSMState 
             break; // how
     }
 }
+
 DECLARE_THREAD(telemetry, RocketSystems* arg) {
     double launch_time = 0;
+    bool has_triggered_vmux_fallback = false;
 
     while (true) {
 
@@ -337,11 +339,13 @@ DECLARE_THREAD(telemetry, RocketSystems* arg) {
 
         if (current_state == FSMState::STATE_IDLE) {
             launch_time = current_time;
+            has_triggered_vmux_fallback = false;
         }
 
-        if ((current_time - launch_time) > 80000) {
+        if ((current_time - launch_time) > 80000 && !has_triggered_vmux_fallback) {
             // THIS IS A HARDCODED VALUE FOR AETHER 3/15/2025
             // If the rocket has been in flight for over 80 seconds, we swap the FSM camera feed to the bulkhead camera
+            has_triggered_vmux_fallback = true;
             arg->rocket_data.command_flags.FSM_should_swap_camera_feed = true;
         }
 

--- a/MIDAS/src/systems.cpp
+++ b/MIDAS/src/systems.cpp
@@ -179,13 +179,13 @@ DECLARE_THREAD(fsm, RocketSystems* arg) {
         if(arg->rocket_data.command_flags.FSM_should_set_cam_feed_cam1) { 
             // Swap camera feed to MUX 1 (Side-facing camera) at launch.
             arg->rocket_data.command_flags.FSM_should_set_cam_feed_cam1 = false;
-            arg->b2b.camera.vmux_set(CAM_1);
+            arg->b2b.camera.vmux_set(SIDE_CAMERA);
         }
 
         if(arg->rocket_data.command_flags.FSM_should_swap_camera_feed) { 
             // Swap camera feed to MUX 2 (recovery bay camera)
             arg->rocket_data.command_flags.FSM_should_swap_camera_feed = false;
-            arg->b2b.camera.vmux_set(CAM_2);
+            arg->b2b.camera.vmux_set(BULKHEAD_CAMERA);
         }
 
         THREAD_SLEEP(50);
@@ -337,6 +337,12 @@ DECLARE_THREAD(telemetry, RocketSystems* arg) {
 
         if (current_state == FSMState::STATE_IDLE) {
             launch_time = current_time;
+        }
+
+        if ((current_time - launch_time) > 80000) {
+            // THIS IS A HARDCODED VALUE FOR AETHER 3/15/2025
+            // If the rocket has been in flight for over 80 seconds, we swap the FSM camera feed to the bulkhead camera
+            arg->rocket_data.command_flags.FSM_should_swap_camera_feed = true;
         }
 
         if (current_state == FSMState(STATE_IDLE) || current_state == FSMState(STATE_SAFE) || current_state == FSMState(STATE_PYRO_TEST) || (current_time - launch_time) > 1800000) {


### PR DESCRIPTION
Adds `SIDE_CAMERA` and `BULKHEAD_CAMERA` macros to easily differentiate between cameras.

Adds an 80 second timer post-launch to swap out the camera view