### PR TITLE
ensure no implicit casts are done for packet.kf_vx packing

### DIFF
--- a/MIDAS/src/telemetry.cpp
+++ b/MIDAS/src/telemetry.cpp
@@ -119,7 +119,8 @@ TelemetryPacket Telemetry::makePacket(RocketData& data) {
     uint8_t sat_count = gps.fix_type;
     packet.fsm_callsign_satcount = ((uint8_t)fsm) | (sat_count << 4);
     float kf_vx_clamped = std::clamp(kalman.velocity.vx, -2000.f, 2000.f);
-    packet.kf_vx = (uint16_t) ((kf_vx_clamped + 2000) / 4000. * ((1 << 16) - 1));
+    // freaky
+    packet.kf_vx = (uint16_t) ((kf_vx_clamped + 2000.f) / 4000.f * ((1 << 16) - 1));
 
     #ifdef IS_SUSTAINER
     packet.fsm_callsign_satcount |= (1 << 7);


### PR DESCRIPTION
This is a draft of a PR to finish an issue tracked on the onboarding issue tracker.

# Description
> KF VX is very suspect. See whether it's an issue with our telemetry bit packing OR an issue with the KF data.

This first bit of code ensures no implicit casting is done. Testing will be done to determine if this fixes the issue or if it's bad KF data.

Once those items are done, this draft will be finalized and turned into a complete PR, ready for review.