### PR TITLE
Fixing MIDAS Base BLE

### DIFF
--- a/ground/gss_combiner/gui_main.py
+++ b/ground/gss_combiner/gui_main.py
@@ -16,6 +16,7 @@ import queue
 
 
 def get_non_bluetooth_ports():
+    # print([port.description for port in comports()])
     return [port.device for port in comports() if "bluetooth" not in port.description.lower()]
 
 def is_port_taken(port):

--- a/ground/gss_combiner/gui_main.py
+++ b/ground/gss_combiner/gui_main.py
@@ -22,7 +22,8 @@ def get_feather_duo_ports():
     Returns:
         list: list of connected Feather Duos
     """
-    return [port.device for port in comports() if port.pid == 4097]
+    FEATHER_DUO_PID = 4097
+    return [port.device for port in comports() if port.pid == FEATHER_DUO_PID]
 
 def is_port_taken(port):
     """

--- a/ground/gss_combiner/gui_main.py
+++ b/ground/gss_combiner/gui_main.py
@@ -16,9 +16,9 @@ import queue
 
 
 def get_non_bluetooth_ports():
-    # print([port.hwid for port in comports()])
+    # print([port.pid for port in comports()])
 
-    return [port.device for port in comports() if "VID:PID=303A:1001" in port.hwid]
+    return [port.device for port in comports() if port.pid == 4097]
 
 def is_port_taken(port):
     """

--- a/ground/gss_combiner/gui_main.py
+++ b/ground/gss_combiner/gui_main.py
@@ -16,8 +16,9 @@ import queue
 
 
 def get_non_bluetooth_ports():
-    # print([port.device for port in comports()])
-    return [port.device for port in comports() if "/dev/cu.usbmodem1101" in port.device.lower()]
+    # print([port.hwid for port in comports()])
+
+    return [port.device for port in comports() if "VID:PID=303A:1001" in port.hwid]
 
 def is_port_taken(port):
     """

--- a/ground/gss_combiner/gui_main.py
+++ b/ground/gss_combiner/gui_main.py
@@ -15,8 +15,8 @@ import sys
 import queue
 
 
-def get_ports():
-    return [port.device for port in comports()]
+def get_non_bluetooth_ports():
+    return [port.device for port in comports() if "bluetooth" not in port.description.lower()]
 
 def is_port_taken(port):
     """
@@ -236,7 +236,7 @@ class DeviceApp(tk.Tk):
 
     def update_devices(self):
         global devices
-        ports = get_ports()
+        ports = get_non_bluetooth_ports()
         existing_ports = [d.get_port() for d in devices]
 
         # Remove old ports that aren't connected
@@ -251,7 +251,6 @@ class DeviceApp(tk.Tk):
                         _window.destroy()
 
         devices = [d for d in devices if d.get_port() in ports]
-
         for p in ports:
             # Check if this port is already in devices:
             if p not in existing_ports:

--- a/ground/gss_combiner/gui_main.py
+++ b/ground/gss_combiner/gui_main.py
@@ -16,8 +16,12 @@ import queue
 
 
 def get_feather_duo_ports():
-    # print([port.pid for port in comports()])
+    """
+    Gets the ports of connected Feather Duos
 
+    Returns:
+    list: list of connected Feather Duos
+    """
     return [port.device for port in comports() if port.pid == 4097]
 
 def is_port_taken(port):

--- a/ground/gss_combiner/gui_main.py
+++ b/ground/gss_combiner/gui_main.py
@@ -16,7 +16,8 @@ import queue
 
 
 def get_non_bluetooth_ports():
-    return [port.device for port in comports() if "bluetooth" not in port.description.lower()]
+    # print([port.device for port in comports()])
+    return [port.device for port in comports() if "/dev/cu.usbmodem1101" in port.device.lower()]
 
 def is_port_taken(port):
     """

--- a/ground/gss_combiner/gui_main.py
+++ b/ground/gss_combiner/gui_main.py
@@ -15,7 +15,7 @@ import sys
 import queue
 
 
-def get_non_bluetooth_ports():
+def get_feather_duo_ports():
     # print([port.pid for port in comports()])
 
     return [port.device for port in comports() if port.pid == 4097]
@@ -238,7 +238,7 @@ class DeviceApp(tk.Tk):
 
     def update_devices(self):
         global devices
-        ports = get_non_bluetooth_ports()
+        ports = get_feather_duo_ports()
         existing_ports = [d.get_port() for d in devices]
 
         # Remove old ports that aren't connected

--- a/ground/gss_combiner/gui_main.py
+++ b/ground/gss_combiner/gui_main.py
@@ -20,7 +20,7 @@ def get_feather_duo_ports():
     Gets the ports of connected Feather Duos
 
     Returns:
-    list: list of connected Feather Duos
+        list: list of connected Feather Duos
     """
     return [port.device for port in comports() if port.pid == 4097]
 


### PR DESCRIPTION
We fixed the issue with Bluetooth causing Midas-Base on Macs and some Windows PCs to crash. We did this by checking the pid of the devices when getting the ports initially. In theory, based on the one feather duo we checked, this works, but it is possible that the pid of other feathers may be different (in theory, based on best practices for USB PIDs, they won't be, but who knows). If so, let us know and it should be a pretty easy fix, assuming we have a comprehensive list of PIDs that they could have.