### PR TITLE
working on metalogging functions after new fsm did stuff

### DIFF
--- a/MIDAS/log_enc.py
+++ b/MIDAS/log_enc.py
@@ -690,6 +690,9 @@ STD_HEADERS = {
     "<cstdint>": "",
     "<math.h>": "",
     "<algorithm>": "",
+    "<limits>": "",
+    "<string.h>": "",
+    "<Queue.h>": "",
 }
 
 

--- a/MIDAS/src/data_logging_meta.h
+++ b/MIDAS/src/data_logging_meta.h
@@ -2,6 +2,7 @@
 #include <Queue.h>
 #include <algorithm>
 #include <limits>
+#include <sensor_data.h>
 
 #define META_LOGGING_MAX_SIZE 64
 
@@ -18,10 +19,14 @@ enum MetaDataCode {
 
     // Non-events
     DATA_LAUNCHSITE_BARO,
-    DATA_LAUNCHSITE_GPS,
+    DATA_LAUNCHSITE_ALT,
+    DATA_LAUNCHSITE_GPS_ALT,
+    DATA_LAUNCHSITE_GPS_LAT,
+    DATA_LAUNCHSITE_GPS_LONG,
     DATA_LAUNCH_INITIAL_TILT,
     DATA_TILT_AT_BURNOUT,
     DATA_TILT_AT_IGNITION,
+    DATA_BARO_AT_IGNITION,
     DATA_MAX_ACCEL,
     DATA_MAX_VEL,
     DATA_ALT_AT_BURNOUT,
@@ -115,10 +120,13 @@ struct MetalogSummary{
 
     // Non-events
     MetalogSummaryEntry<float> data_launchsite_baro {MetaDataCode::DATA_LAUNCHSITE_BARO};
-    MetalogSummaryEntry<float> data_launchsite_gps {MetaDataCode::DATA_LAUNCHSITE_GPS};
+    MetalogSummaryEntry<uint32_t> data_launchsite_gps_alt {MetaDataCode::DATA_LAUNCHSITE_GPS_ALT};
+    MetalogSummaryEntry<uint32_t> data_launchsite_gps_lat {MetaDataCode::DATA_LAUNCHSITE_GPS_LAT};
+    MetalogSummaryEntry<uint32_t> data_launchsite_gps_long {MetaDataCode::DATA_LAUNCHSITE_GPS_LONG};
     MetalogSummaryEntry<float> data_launch_initial_tilt {MetaDataCode::DATA_LAUNCH_INITIAL_TILT};
     MetalogSummaryEntry<float> data_tilt_at_burnout {MetaDataCode::DATA_TILT_AT_BURNOUT};
     MetalogSummaryEntry<float> data_tilt_at_ignition {MetaDataCode::DATA_TILT_AT_IGNITION};
+    MetalogSummaryEntry<float> data_baro_at_ignition {MetaDataCode::DATA_BARO_AT_IGNITION};
     MetalogSummaryEntry<float> data_max_accel {MetaDataCode::DATA_MAX_ACCEL, MetalogSummaryEntryType::MAXIMUM, -std::numeric_limits<float>::max()};
     MetalogSummaryEntry<float> data_max_vel {MetaDataCode::DATA_MAX_VEL, MetalogSummaryEntryType::MAXIMUM, -std::numeric_limits<float>::max()};
     MetalogSummaryEntry<float> data_alt_at_burnout {MetaDataCode::DATA_ALT_AT_BURNOUT};

--- a/MIDAS/src/data_logging_meta.h
+++ b/MIDAS/src/data_logging_meta.h
@@ -1,5 +1,7 @@
 #include <string.h>
 #include <Queue.h>
+#include <algorithm>
+#include <limits>
 
 #define META_LOGGING_MAX_SIZE 64
 
@@ -26,11 +28,41 @@ enum MetaDataCode {
     DATA_MAX_DESCENT_RATE
 };
 
-
 enum class MetalogSummaryEntryType{
     CURRENT,
     MAXIMUM,
     MINIMUM,
+};
+
+struct MetalogSummary;
+
+struct MetaLogging {
+    public:
+        struct MetaLogEntry {
+            MetaDataCode log_type;
+            size_t size;
+            char data[META_LOGGING_MAX_SIZE];
+        };
+
+        MetalogSummary * summary;
+
+        Queue<MetaLogEntry> _q;
+
+        bool get_queued(MetaLogEntry* out) { return _q.receive(out); }
+
+        template <typename T>
+        void log_data(MetaDataCode data_type, const T& data) {
+
+            // double check...
+            static_assert(sizeof(T) <= META_LOGGING_MAX_SIZE, "Datatype for log_data too large");
+
+            MetaLogEntry entry{data_type, 0, 0};
+            entry.size = sizeof(T);
+            memcpy(entry.data, &data, entry.size);
+            _q.send(entry);
+
+            // fprintf(stderr, "Data has been logged: %c", entry.data);
+        }
 };
 
 template<typename T>
@@ -38,9 +70,9 @@ class MetalogSummaryEntry {
 
     public:
 
-    MetalogSummaryEntry(const MetaDataCode &code, const MetalogSummaryEntryType &type = MetalogSummaryEntryType::CURRENT, const T &default_val = T()){
-        code = code;
-        type = type;
+    MetalogSummaryEntry(const MetaDataCode &metacode, const MetalogSummaryEntryType &metatype = MetalogSummaryEntryType::CURRENT, const T &default_val = T()){
+        code = metacode;
+        type = metatype;
         data = default_val;
     }
 
@@ -62,9 +94,7 @@ class MetalogSummaryEntry {
         }
     }
 
-    void commit(MetaLogging &metalog){
-        metalog.log_data(code, data);
-    }
+    void commit(MetaLogging &metalog);
 
     private:
         T data;
@@ -95,31 +125,6 @@ struct MetalogSummary{
     MetalogSummaryEntry<float> data_max_descent_rate {MetaDataCode::DATA_MAX_DESCENT_RATE, MetalogSummaryEntryType::MAXIMUM, -std::numeric_limits<float>::max()};
 };
 
-struct MetaLogging {
-    public:
-        struct MetaLogEntry {
-            MetaDataCode log_type;
-            size_t size;
-            char data[META_LOGGING_MAX_SIZE];
-        };
+template <typename T>
+void MetalogSummaryEntry<T>::commit(MetaLogging &metalog){metalog.log_data(code, data);}
 
-        MetalogSummary summary;
-
-        Queue<MetaLogEntry> _q;
-
-        bool get_queued(MetaLogEntry* out) { return _q.receive(out); }
-
-        template <typename T>
-        void log_data(MetaDataCode data_type, const T& data) {
-
-            // double check...
-            static_assert(sizeof(T) <= META_LOGGING_MAX_SIZE, "Datatype for log_data too large");
-
-            MetaLogEntry entry{data_type, 0, 0};
-            entry.size = sizeof(T);
-            memcpy(entry.data, &data, entry.size);
-            _q.send(entry);
-
-            // fprintf(stderr, "Data has been logged: %c", entry.data);
-        }
-};

--- a/MIDAS/src/data_logging_meta.h
+++ b/MIDAS/src/data_logging_meta.h
@@ -38,13 +38,6 @@ struct MetaLogging {
 
         bool get_queued(MetaLogEntry* out) { return _q.receive(out); }
 
-        void log_event(MetaDataCode event_type, uint32_t timestamp) {
-            MetaLogEntry entry{event_type, 0, 0};
-            entry.size = sizeof(uint32_t);
-            memcpy(entry.data, &timestamp, entry.size);
-            _q.send(entry);
-        }
-
         template <typename T>
         void log_data(MetaDataCode data_type, const T& data) {
 

--- a/MIDAS/src/data_logging_meta.h
+++ b/MIDAS/src/data_logging_meta.h
@@ -26,6 +26,75 @@ enum MetaDataCode {
     DATA_MAX_DESCENT_RATE
 };
 
+
+enum class MetalogSummaryEntryType{
+    CURRENT,
+    MAXIMUM,
+    MINIMUM,
+};
+
+template<typename T>
+class MetalogSummaryEntry {
+
+    public:
+
+    MetalogSummaryEntry(const MetaDataCode &code, const MetalogSummaryEntryType &type = MetalogSummaryEntryType::CURRENT, const T &default_val = T()){
+        code = code;
+        type = type;
+        data = default_val;
+    }
+
+    void update(const T &newval){
+        switch(type){
+            case MetalogSummaryEntryType::CURRENT:
+                data = newval;
+                break;
+            case MetalogSummaryEntryType::MAXIMUM:
+                if (newval > data){
+                    data = newval;
+                }
+                break;
+            case MetalogSummaryEntryType::MINIMUM:
+                if (newval < data){
+                    data = newval;
+                }
+                break;
+        }
+    }
+
+    void commit(MetaLogging &metalog){
+        metalog.log_data(code, data);
+    }
+
+    private:
+        T data;
+        MetaDataCode code;
+        MetalogSummaryEntryType type;  
+};
+
+struct MetalogSummary{
+    // Launch events
+    MetalogSummaryEntry<uint32_t> event_tlaunch {MetaDataCode::EVENT_TLAUNCH};
+    MetalogSummaryEntry<uint32_t> event_tburnout {MetaDataCode::EVENT_TBURNOUT};
+    MetalogSummaryEntry<uint32_t> event_tignition {MetaDataCode::EVENT_TIGNITION};
+    MetalogSummaryEntry<uint32_t> event_tapogee {MetaDataCode::EVENT_TAPOGEE};
+    MetalogSummaryEntry<uint32_t> event_tmain {MetaDataCode::EVENT_TMAIN};
+    MetalogSummaryEntry<uint32_t> event_tmax_accel {MetaDataCode::EVENT_TMAX_ACCEL};
+    MetalogSummaryEntry<uint32_t> event_tmax_vel {MetaDataCode::EVENT_TMAX_VEL};
+    MetalogSummaryEntry<uint32_t> event_tmax_descent_rate {MetaDataCode::EVENT_TMAX_DESCENT_RATE};
+
+    // Non-events
+    MetalogSummaryEntry<float> data_launchsite_baro {MetaDataCode::DATA_LAUNCHSITE_BARO};
+    MetalogSummaryEntry<float> data_launchsite_gps {MetaDataCode::DATA_LAUNCHSITE_GPS};
+    MetalogSummaryEntry<float> data_launch_initial_tilt {MetaDataCode::DATA_LAUNCH_INITIAL_TILT};
+    MetalogSummaryEntry<float> data_tilt_at_burnout {MetaDataCode::DATA_TILT_AT_BURNOUT};
+    MetalogSummaryEntry<float> data_tilt_at_ignition {MetaDataCode::DATA_TILT_AT_IGNITION};
+    MetalogSummaryEntry<float> data_max_accel {MetaDataCode::DATA_MAX_ACCEL, MetalogSummaryEntryType::MAXIMUM, -std::numeric_limits<float>::max()};
+    MetalogSummaryEntry<float> data_max_vel {MetaDataCode::DATA_MAX_VEL, MetalogSummaryEntryType::MAXIMUM, -std::numeric_limits<float>::max()};
+    MetalogSummaryEntry<float> data_alt_at_burnout {MetaDataCode::DATA_ALT_AT_BURNOUT};
+    MetalogSummaryEntry<float> data_max_descent_rate {MetaDataCode::DATA_MAX_DESCENT_RATE, MetalogSummaryEntryType::MAXIMUM, -std::numeric_limits<float>::max()};
+};
+
 struct MetaLogging {
     public:
         struct MetaLogEntry {
@@ -33,6 +102,8 @@ struct MetaLogging {
             size_t size;
             char data[META_LOGGING_MAX_SIZE];
         };
+
+        MetalogSummary summary;
 
         Queue<MetaLogEntry> _q;
 

--- a/MIDAS/src/finite-state-machines/fsm.h
+++ b/MIDAS/src/finite-state-machines/fsm.h
@@ -61,6 +61,8 @@ public:
     // Sets CRC to the fail state, preventing any pyro action.
     void set_crc_fail() { config.crc32 = FSM_CRC_FAIL_STATE; };
 
+    bool get_cur_state_lockin() { return cur_state_lockin; }
+
 private:
     FSMConfiguration config;
     double pyro_test_entry_time;

--- a/MIDAS/src/sensor_data.h
+++ b/MIDAS/src/sensor_data.h
@@ -3,9 +3,10 @@
 #include <cmath>
 #include <cstdint>
 #include <algorithm>
+#include <limits>
 
 #include "finite-state-machines/fsm_config.h"
-
+#include "data_logging_meta.h"
 
 /**
  * @brief
@@ -148,6 +149,75 @@ struct IMU_SFLP {
     Quaternion quaternion;
     Acceleration gravity;
     Velocity gyro_bias;
+};
+
+
+enum class MetalogSummaryEntryType{
+    CURRENT,
+    MAXIMUM,
+    MINIMUM,
+};
+
+template<typename T>
+class MetalogSummaryEntry {
+
+    public:
+
+    MetalogSummaryEntry(const MetaDataCode &code, const MetalogSummaryEntryType &type = MetalogSummaryEntryType::CURRENT, const T &default_val = T()){
+        code = code;
+        type = type;
+        data = default_val;
+    }
+
+    void update(const T &newval){
+        switch(type){
+            case MetalogSummaryEntryType::CURRENT:
+                data = newval;
+                break;
+            case MetalogSummaryEntryType::MAXIMUM:
+                if (newval > data){
+                    data = newval;
+                }
+                break;
+            case MetalogSummaryEntryType::MINIMUM:
+                if (newval < data){
+                    data = newval;
+                }
+                break;
+        }
+    }
+
+    void commit(MetaLogging &metalog){
+        metalog.log_data(code, data);
+    }
+
+    private:
+        T data;
+        MetaDataCode code;
+        MetalogSummaryEntryType type;  
+};
+
+struct MetalogSummary{
+    // Launch events
+    MetalogSummaryEntry<uint32_t> event_tlaunch {MetaDataCode::EVENT_TLAUNCH};
+    MetalogSummaryEntry<uint32_t> event_tburnout {MetaDataCode::EVENT_TBURNOUT};
+    MetalogSummaryEntry<uint32_t> event_tignition {MetaDataCode::EVENT_TIGNITION};
+    MetalogSummaryEntry<uint32_t> event_tapogee {MetaDataCode::EVENT_TAPOGEE};
+    MetalogSummaryEntry<uint32_t> event_tmain {MetaDataCode::EVENT_TMAIN};
+    MetalogSummaryEntry<uint32_t> event_tmax_accel {MetaDataCode::EVENT_TMAX_ACCEL};
+    MetalogSummaryEntry<uint32_t> event_tmax_vel {MetaDataCode::EVENT_TMAX_VEL};
+    MetalogSummaryEntry<uint32_t> event_tmax_descent_rate {MetaDataCode::EVENT_TMAX_DESCENT_RATE};
+
+    // Non-events
+    MetalogSummaryEntry<float> data_launchsite_baro {MetaDataCode::DATA_LAUNCHSITE_BARO};
+    MetalogSummaryEntry<float> data_launchsite_gps {MetaDataCode::DATA_LAUNCHSITE_GPS};
+    MetalogSummaryEntry<float> data_launch_initial_tilt {MetaDataCode::DATA_LAUNCH_INITIAL_TILT};
+    MetalogSummaryEntry<float> data_tilt_at_burnout {MetaDataCode::DATA_TILT_AT_BURNOUT};
+    MetalogSummaryEntry<float> data_tilt_at_ignition {MetaDataCode::DATA_TILT_AT_IGNITION};
+    MetalogSummaryEntry<float> data_max_accel {MetaDataCode::DATA_MAX_ACCEL, MetalogSummaryEntryType::MAXIMUM, -std::numeric_limits<float>::max()};
+    MetalogSummaryEntry<float> data_max_vel {MetaDataCode::DATA_MAX_VEL, MetalogSummaryEntryType::MAXIMUM, -std::numeric_limits<float>::max()};
+    MetalogSummaryEntry<float> data_alt_at_burnout {MetaDataCode::DATA_ALT_AT_BURNOUT};
+    MetalogSummaryEntry<float> data_max_descent_rate {MetaDataCode::DATA_MAX_DESCENT_RATE, MetalogSummaryEntryType::MAXIMUM, -std::numeric_limits<float>::max()};
 };
 
 /**

--- a/MIDAS/src/sensor_data.h
+++ b/MIDAS/src/sensor_data.h
@@ -6,7 +6,6 @@
 #include <limits>
 
 #include "finite-state-machines/fsm_config.h"
-#include "data_logging_meta.h"
 
 /**
  * @brief
@@ -151,74 +150,6 @@ struct IMU_SFLP {
     Velocity gyro_bias;
 };
 
-
-enum class MetalogSummaryEntryType{
-    CURRENT,
-    MAXIMUM,
-    MINIMUM,
-};
-
-template<typename T>
-class MetalogSummaryEntry {
-
-    public:
-
-    MetalogSummaryEntry(const MetaDataCode &code, const MetalogSummaryEntryType &type = MetalogSummaryEntryType::CURRENT, const T &default_val = T()){
-        code = code;
-        type = type;
-        data = default_val;
-    }
-
-    void update(const T &newval){
-        switch(type){
-            case MetalogSummaryEntryType::CURRENT:
-                data = newval;
-                break;
-            case MetalogSummaryEntryType::MAXIMUM:
-                if (newval > data){
-                    data = newval;
-                }
-                break;
-            case MetalogSummaryEntryType::MINIMUM:
-                if (newval < data){
-                    data = newval;
-                }
-                break;
-        }
-    }
-
-    void commit(MetaLogging &metalog){
-        metalog.log_data(code, data);
-    }
-
-    private:
-        T data;
-        MetaDataCode code;
-        MetalogSummaryEntryType type;  
-};
-
-struct MetalogSummary{
-    // Launch events
-    MetalogSummaryEntry<uint32_t> event_tlaunch {MetaDataCode::EVENT_TLAUNCH};
-    MetalogSummaryEntry<uint32_t> event_tburnout {MetaDataCode::EVENT_TBURNOUT};
-    MetalogSummaryEntry<uint32_t> event_tignition {MetaDataCode::EVENT_TIGNITION};
-    MetalogSummaryEntry<uint32_t> event_tapogee {MetaDataCode::EVENT_TAPOGEE};
-    MetalogSummaryEntry<uint32_t> event_tmain {MetaDataCode::EVENT_TMAIN};
-    MetalogSummaryEntry<uint32_t> event_tmax_accel {MetaDataCode::EVENT_TMAX_ACCEL};
-    MetalogSummaryEntry<uint32_t> event_tmax_vel {MetaDataCode::EVENT_TMAX_VEL};
-    MetalogSummaryEntry<uint32_t> event_tmax_descent_rate {MetaDataCode::EVENT_TMAX_DESCENT_RATE};
-
-    // Non-events
-    MetalogSummaryEntry<float> data_launchsite_baro {MetaDataCode::DATA_LAUNCHSITE_BARO};
-    MetalogSummaryEntry<float> data_launchsite_gps {MetaDataCode::DATA_LAUNCHSITE_GPS};
-    MetalogSummaryEntry<float> data_launch_initial_tilt {MetaDataCode::DATA_LAUNCH_INITIAL_TILT};
-    MetalogSummaryEntry<float> data_tilt_at_burnout {MetaDataCode::DATA_TILT_AT_BURNOUT};
-    MetalogSummaryEntry<float> data_tilt_at_ignition {MetaDataCode::DATA_TILT_AT_IGNITION};
-    MetalogSummaryEntry<float> data_max_accel {MetaDataCode::DATA_MAX_ACCEL, MetalogSummaryEntryType::MAXIMUM, -std::numeric_limits<float>::max()};
-    MetalogSummaryEntry<float> data_max_vel {MetaDataCode::DATA_MAX_VEL, MetalogSummaryEntryType::MAXIMUM, -std::numeric_limits<float>::max()};
-    MetalogSummaryEntry<float> data_alt_at_burnout {MetaDataCode::DATA_ALT_AT_BURNOUT};
-    MetalogSummaryEntry<float> data_max_descent_rate {MetaDataCode::DATA_MAX_DESCENT_RATE, MetalogSummaryEntryType::MAXIMUM, -std::numeric_limits<float>::max()};
-};
 
 /**
  * 

--- a/MIDAS/src/systems.cpp
+++ b/MIDAS/src/systems.cpp
@@ -154,7 +154,7 @@ DECLARE_THREAD(imuthread, RocketSystems *arg)
         if(!has_logged) {
             if(arg->rocket_data.fsm_state.getRecentUnsync().state == FSMState::STATE_LANDED) {
                 arg->meta_logging.log_data(MetaDataCode::DATA_MAX_ACCEL, max_accel);
-                arg->meta_logging.log_event(MetaDataCode::EVENT_TMAX_ACCEL, max_accel_time);
+                arg->meta_logging.log_data(MetaDataCode::EVENT_TMAX_ACCEL, max_accel_time);
                 has_logged = true;
             }
         }
@@ -263,13 +263,14 @@ void fsm_transitioned_to(FSMState& new_state, FSMState& old_state, RocketSystems
     AngularKalmanData cur_orientation = sys->rocket_data.angular_kalman_data.getRecentUnsync();
     switch (new_state) {
         case FSMState::STATE_BOOST:
-            sys->meta_logging.log_event(MetaDataCode::EVENT_TLAUNCH, current_time);
+        //only want to log this when first boost, not following
+            sys->meta_logging.log_data(MetaDataCode::EVENT_TLAUNCH, current_time);
             sys->meta_logging.log_data(MetaDataCode::DATA_LAUNCHSITE_BARO, sys->rocket_data.barometer.getRecentUnsync());
             sys->meta_logging.log_data(MetaDataCode::DATA_LAUNCHSITE_GPS, sys->rocket_data.gps.getRecentUnsync());
             sys->meta_logging.log_data(MetaDataCode::DATA_LAUNCH_INITIAL_TILT, cur_orientation.sflp_tilt);
             break;
         case FSMState::STATE_COAST:
-            sys->meta_logging.log_event(MetaDataCode::EVENT_TBURNOUT, current_time);
+            sys->meta_logging.log_data(MetaDataCode::EVENT_TBURNOUT, current_time);
             sys->meta_logging.log_data(MetaDataCode::DATA_TILT_AT_BURNOUT, cur_orientation.sflp_tilt);
             sys->meta_logging.log_data(MetaDataCode::DATA_ALT_AT_BURNOUT, sys->rocket_data.barometer.getRecentUnsync().altitude);
             break;
@@ -278,14 +279,18 @@ void fsm_transitioned_to(FSMState& new_state, FSMState& old_state, RocketSystems
         //     sys->meta_logging.log_data(MetaDataCode::DATA_TILT_AT_IGNITION, cur_orientation.sflp_tilt);
         //     break;
         case FSMState::STATE_DROGUE:
-            sys->meta_logging.log_event(MetaDataCode::EVENT_TAPOGEE, current_time);
+            sys->meta_logging.log_data(MetaDataCode::EVENT_TAPOGEE, current_time);
             break;
         case FSMState::STATE_MAIN:
-            sys->meta_logging.log_event(MetaDataCode::EVENT_TMAIN, current_time);
+            sys->meta_logging.log_data(MetaDataCode::EVENT_TMAIN, current_time);
             break;
         default:
             break;
     }
+}
+
+void fsm_state_commit(FSMState& current_state, RocketSystems* sys) {
+
 }
 
 // This thread has a bit of extra logic since it needs to play a tune exactly once the sustainer ignites
@@ -322,14 +327,22 @@ DECLARE_THREAD(fsm, RocketSystems *arg)
 
         FSMState current_state = current_state_data.state;
 
-        FSMTickData tick_data = {current_state_data, telemetry_commands, state_estimate, kfd, fsm_cfg, current_time};
+        bool last_lockin_state = fsm.get_cur_state_lockin();
 
+        FSMTickData tick_data = {current_state_data, telemetry_commands, state_estimate, kfd, fsm_cfg, current_time};
+        
         FSMData next_state = fsm.tick_fsm(tick_data);
 
         arg->rocket_data.fsm_state.update(next_state);
         
         if(current_state != next_state.state) {
             fsm_transitioned_to(next_state.state, current_state, arg, current_time);       
+        }
+        else {
+            if (last_lockin_state != fsm.get_cur_state_lockin() ) {
+                fsm_state_commit(current_state, arg);
+            }
+
         }
 
         if(arg->rocket_data.err_flags.encode() != 0) {
@@ -407,7 +420,7 @@ DECLARE_THREAD(fsm, RocketSystems *arg)
         if(!has_logged) {
             if(arg->rocket_data.fsm_state.getRecentUnsync().state == FSMState::STATE_LANDED) {
                 arg->meta_logging.log_data(MetaDataCode::DATA_MAX_DESCENT_RATE, max_descent_rate);
-                arg->meta_logging.log_event(MetaDataCode::EVENT_TMAX_DESCENT_RATE, max_descent_rate_time);
+                arg->meta_logging.log_data(MetaDataCode::EVENT_TMAX_DESCENT_RATE, max_descent_rate_time);
                 has_logged = true;
             }
         }
@@ -547,7 +560,7 @@ DECLARE_THREAD(kalman, RocketSystems *arg)
         if(!has_logged) {
             if(arg->rocket_data.fsm_state.getRecentUnsync().state == FSMState::STATE_LANDED) {
                 arg->meta_logging.log_data(MetaDataCode::DATA_MAX_VEL, max_vel);
-                arg->meta_logging.log_event(MetaDataCode::EVENT_TMAX_ACCEL, max_vel_time);
+                arg->meta_logging.log_data(MetaDataCode::EVENT_TMAX_ACCEL, max_vel_time);
                 has_logged = true;
             }
         }

--- a/MIDAS/src/systems.cpp
+++ b/MIDAS/src/systems.cpp
@@ -35,6 +35,9 @@ DECLARE_THREAD(logger, RocketSystems *arg)
     log_begin(arg->log_sink);
     int meta_delay_ctr = 0; //  Will cause meta logs to write slower intentionally
 
+    MetalogSummary s;
+    arg->meta_logging.summary = &s;
+    
     constexpr size_t meta_logging_header_size = (sizeof(size_t)*8) + EEPROM_SIZE + sizeof(LogFormatMetaEntry)*(LOG_META_ENTRY_COUNT+EEPROM_META_ENTRY_COUNT) + sizeof(LogDiscMapEntry)*LOG_DISCMAP_COUNT;
 
     // Write header size
@@ -258,41 +261,96 @@ DECLARE_THREAD(voltage, RocketSystems* arg) {
 
 //run threads
 
-void fsm_transitioned_to(FSMState& new_state, FSMState& old_state, RocketSystems* sys, double current_time) {
+void fsm_transitioned_to(FSMData& new_state, FSMData& old_state, RocketSystems* sys, double current_time) {
     // Do something, NO delays allowed!
-    AngularKalmanData cur_orientation = sys->rocket_data.angular_kalman_data.getRecentUnsync();
-    switch (new_state) {
-        case FSMState::STATE_BOOST:
-        //only want to log this when first boost, not following
-            sys->meta_logging.summary->event_tlaunch.update(current_time);
-            sys->meta_logging.summary->data_launchsite_baro.update(sys->rocket_data.barometer.getRecentUnsync());
 
-            // sys->meta_logging.log_data(MetaDataCode::DATA_LAUNCHSITE_BARO, sys->rocket_data.barometer.getRecentUnsync());
-            sys->meta_logging.log_data(MetaDataCode::DATA_LAUNCHSITE_GPS, sys->rocket_data.gps.getRecentUnsync());
-            sys->meta_logging.log_data(MetaDataCode::DATA_LAUNCH_INITIAL_TILT, cur_orientation.sflp_tilt);
+    switch (new_state.state) {
+        case FSMState::STATE_BOOST:
+        //first stage specific logging
+            if(new_state.current_motor == 0){
+                sys->meta_logging.summary->event_tlaunch.update(current_time);
+                
+                sys->meta_logging.summary->data_launchsite_baro.update(sys->rocket_data.barometer.getRecentUnsync().altitude);
+                
+                sys->meta_logging.summary->data_launchsite_gps_alt.update(sys->rocket_data.gps.getRecentUnsync().altitude);
+                sys->meta_logging.summary->data_launchsite_gps_lat.update(sys->rocket_data.gps.getRecentUnsync().latitude);
+                sys->meta_logging.summary->data_launchsite_gps_long.update(sys->rocket_data.gps.getRecentUnsync().longitude);
+                
+                sys->meta_logging.summary->data_launch_initial_tilt.update(sys->rocket_data.angular_kalman_data.getRecentUnsync().mq_tilt);
+            }
+        //all other stages logging
+            else{
+                sys->meta_logging.summary->event_tignition.update(current_time);
+                sys->meta_logging.summary->data_tilt_at_ignition.update(sys->rocket_data.angular_kalman_data.getRecentUnsync().mq_tilt);
+                sys->meta_logging.summary->data_baro_at_ignition.update(sys->rocket_data.barometer.getRecentUnsync().altitude);
+
+            }
+
             break;
+
         case FSMState::STATE_COAST:
-            sys->meta_logging.log_data(MetaDataCode::EVENT_TBURNOUT, current_time);
-            sys->meta_logging.log_data(MetaDataCode::DATA_TILT_AT_BURNOUT, cur_orientation.sflp_tilt);
-            sys->meta_logging.log_data(MetaDataCode::DATA_ALT_AT_BURNOUT, sys->rocket_data.barometer.getRecentUnsync().altitude);
+            sys->meta_logging.summary->event_tburnout.update(current_time);
+            sys->meta_logging.summary->data_tilt_at_burnout.update(sys->rocket_data.angular_kalman_data.getRecentUnsync().mq_tilt);
+            sys->meta_logging.summary->data_alt_at_burnout.update(sys->rocket_data.barometer.getRecentUnsync().altitude);
+
             break;
-        // case FSMState::STATE_SECOND_BOOST:
-        //     sys->meta_logging.log_event(MetaDataCode::EVENT_TIGNITION, current_time);
-        //     sys->meta_logging.log_data(MetaDataCode::DATA_TILT_AT_IGNITION, cur_orientation.sflp_tilt);
-        //     break;
+
         case FSMState::STATE_DROGUE:
-            sys->meta_logging.log_data(MetaDataCode::EVENT_TAPOGEE, current_time);
+            sys->meta_logging.summary->event_tapogee.update(current_time);
+
             break;
         case FSMState::STATE_MAIN:
-            sys->meta_logging.log_data(MetaDataCode::EVENT_TMAIN, current_time);
+            sys->meta_logging.summary->event_tmain.update(current_time);
             break;
         default:
             break;
     }
 }
 
-void fsm_state_commit(FSMState& current_state, RocketSystems* sys) {
+void fsm_state_commit(FSMData& current_state, RocketSystems* sys) {
+    // Do something, NO delays allowed!
 
+    switch (current_state.state) {
+        case FSMState::STATE_BOOST:
+        //first stage specific logging
+            if(current_state.current_motor == 0){
+                sys->meta_logging.summary->event_tlaunch.commit(sys->meta_logging);
+                
+                sys->meta_logging.summary->data_launchsite_baro.commit(sys->meta_logging);
+                
+                sys->meta_logging.summary->data_launchsite_gps_alt.commit(sys->meta_logging);
+                sys->meta_logging.summary->data_launchsite_gps_lat.commit(sys->meta_logging);
+                sys->meta_logging.summary->data_launchsite_gps_long.commit(sys->meta_logging);
+                
+                sys->meta_logging.summary->data_launch_initial_tilt.commit(sys->meta_logging);
+            }
+        //all other stages logging
+            else{
+                sys->meta_logging.summary->event_tignition.commit(sys->meta_logging);
+                sys->meta_logging.summary->data_tilt_at_ignition.commit(sys->meta_logging);
+                sys->meta_logging.summary->data_baro_at_ignition.commit(sys->meta_logging);
+
+            }
+
+            break;
+
+        case FSMState::STATE_COAST:
+            sys->meta_logging.summary->event_tburnout.commit(sys->meta_logging);
+            sys->meta_logging.summary->data_tilt_at_burnout.commit(sys->meta_logging);
+            sys->meta_logging.summary->data_alt_at_burnout.commit(sys->meta_logging);
+
+            break;
+
+        case FSMState::STATE_DROGUE:
+            sys->meta_logging.summary->event_tapogee.commit(sys->meta_logging);
+
+            break;
+        case FSMState::STATE_MAIN:
+            sys->meta_logging.summary->event_tmain.commit(sys->meta_logging);
+            break;
+        default:
+            break;
+    }
 }
 
 // This thread has a bit of extra logic since it needs to play a tune exactly once the sustainer ignites
@@ -338,11 +396,11 @@ DECLARE_THREAD(fsm, RocketSystems *arg)
         arg->rocket_data.fsm_state.update(next_state);
         
         if(current_state != next_state.state) {
-            fsm_transitioned_to(next_state.state, current_state, arg, current_time);       
+            fsm_transitioned_to(next_state, current_state_data, arg, current_time);       
         }
         else {
             if (last_lockin_state != fsm.get_cur_state_lockin() ) {
-                fsm_state_commit(current_state, arg);
+                fsm_state_commit(current_state_data, arg);
             }
 
         }

--- a/MIDAS/src/systems.cpp
+++ b/MIDAS/src/systems.cpp
@@ -264,8 +264,10 @@ void fsm_transitioned_to(FSMState& new_state, FSMState& old_state, RocketSystems
     switch (new_state) {
         case FSMState::STATE_BOOST:
         //only want to log this when first boost, not following
-            sys->meta_logging.log_data(MetaDataCode::EVENT_TLAUNCH, current_time);
-            sys->meta_logging.log_data(MetaDataCode::DATA_LAUNCHSITE_BARO, sys->rocket_data.barometer.getRecentUnsync());
+            sys->meta_logging.summary->event_tlaunch.update(current_time);
+            sys->meta_logging.summary->data_launchsite_baro.update(sys->rocket_data.barometer.getRecentUnsync());
+
+            // sys->meta_logging.log_data(MetaDataCode::DATA_LAUNCHSITE_BARO, sys->rocket_data.barometer.getRecentUnsync());
             sys->meta_logging.log_data(MetaDataCode::DATA_LAUNCHSITE_GPS, sys->rocket_data.gps.getRecentUnsync());
             sys->meta_logging.log_data(MetaDataCode::DATA_LAUNCH_INITIAL_TILT, cur_orientation.sflp_tilt);
             break;


### PR DESCRIPTION
Metalogging now works with new fsm and also accounts for more than 2 stages (future proofing). Metalogging now primarily lives in data_logging_meta.h and is templated btw. This primarily changed data_logging_meta.h and systems (i think).