### PR TITLE
Increase GPS measurement output rate

### DIFF
--- a/MIDAS/lib/ADS7138Q1/ads7138-q1.cpp
+++ b/MIDAS/lib/ADS7138Q1/ads7138-q1.cpp
@@ -16,6 +16,9 @@ extern SemaphoreHandle_t i2c_mutex;
 #define ADC_REG_READ_CONTINUOUS 0x30
 #define ADC_REG_WRITE_CONTINUOUS 0x28
 #define ADC_SYSTEM_STATUS 0x00
+#define ADC_GENERAL_CFG 0x01
+#define ADC_OSR_CFG 0x03
+#define ADC_OPMODE_CFG 0x04
 #define ADC_MANUAL_CH_SEL 0x11
 #define ADC_SEQUENCE_CFG 0x10
 #define ADC_AUTO_SEQ_CH_SEL 0x12
@@ -34,9 +37,27 @@ bool ADS7138::init(TwoWire* i2c, uint8_t addr) {
     return false; // Failed to contact chip or failed to read
   }
 
+  Serial.print("ADC RES ");
+  Serial.println(res, HEX);
+
   // Set sequencing channels
   uint8_t enable_byte = 0b11110111; // All channels but channel 3
   if(!reg_write_single(ADC_AUTO_SEQ_CH_SEL, enable_byte)) {
+    return false;
+  }
+
+  // STATS_EN bit lets us read the RECENT_CH* channels
+  if(!reg_write_single_bitset(ADC_GENERAL_CFG, 0b00100000)) {
+    return false;
+  }
+
+  // CONV_MODE bit outputs values on internal clock
+  if(!reg_write_single_bitset(ADC_OPMODE_CFG, 0b00100000)) {
+    return false;
+  }
+
+  // Set OSR to 8 samples
+  if(!reg_write_single_bitset(ADC_OPMODE_CFG, 0b00000011)) {
     return false;
   }
 
@@ -54,7 +75,7 @@ void ADS7138::tick() {
   reg_read_block(ADC_CHANNEL_READ_START, 16, buf);
 
   for(int i = 0; i < 8; i++) {
-    _ch_readings[i] = buf[i] + (buf[i+1] << 8);
+    _ch_readings[i] = buf[i*2] + (buf[(i*2)+1] << 8);
   }
 }
 
@@ -90,6 +111,22 @@ bool ADS7138::reg_read_single(uint8_t addr, uint8_t& outval) {
     outval = WIRE.read();
     i2c_unlock();
     return true;
+}
+
+bool ADS7138::reg_write_single_bitset(uint8_t reg_address, uint8_t set_mask) {
+  i2c_lock();
+  _i2c->beginTransmission(_i2c_addr);
+  _i2c->write(ADC_SET_BIT);
+  _i2c->write(reg_address);
+  _i2c->write(set_mask);
+  if(_i2c->endTransmission(true) != 0){
+    i2c_unlock();
+    Serial.print("[ADS7138] Failed to write bit mask to addr 0x");
+    Serial.println(reg_address, HEX);
+    return false;
+  }
+  i2c_unlock();
+  return true;
 }
 
 bool ADS7138::reg_write_single(uint8_t reg_address, uint8_t data) {
@@ -144,6 +181,7 @@ bool ADS7138::reg_read_block(uint8_t start_addr, size_t num_reg, uint8_t* out_bu
 
 float ADS7138::read(uint8_t pin) {
   uint16_t raw_value = _ch_readings[pin];
+
   float abs_voltage = ((static_cast<float>(raw_value) / kADCRegisterWidth) * kADCVoltageReference) / kADCPinConversionFactors[pin];
   return abs_voltage;
 }

--- a/MIDAS/lib/ADS7138Q1/ads7138-q1.cpp
+++ b/MIDAS/lib/ADS7138Q1/ads7138-q1.cpp
@@ -1,6 +1,10 @@
 #include "ads7138-q1.h"
 #include<Arduino.h>
-#include<Wire.h>
+#include <freertos/FreeRTOS.h>
+#include <freertos/semphr.h>
+
+// see systems.cpp
+extern SemaphoreHandle_t i2c_mutex;
 
 #define WIRE Wire
 
@@ -13,67 +17,133 @@
 #define ADC_REG_WRITE_CONTINUOUS 0x28
 #define ADC_SYSTEM_STATUS 0x00
 #define ADC_MANUAL_CH_SEL 0x11
+#define ADC_SEQUENCE_CFG 0x10
+#define ADC_AUTO_SEQ_CH_SEL 0x12
+#define ADC_CHANNEL_READ_START 0xA0
 
-struct AdcRegReadResult {
-  int value;
-  AdcError error;
-};
+constexpr float kADCRegisterWidth = static_cast<float>(1 << 16);
+constexpr float kADCVoltageReference = 3.3f;
 
-static AdcRegReadResult adc_reg_read(uint8_t address, uint8_t reg_address) {
-  WIRE.beginTransmission(address);
-  WIRE.write(ADC_REG_READ);
-  WIRE.write(reg_address);
-  if(WIRE.endTransmission(true) != 0){
-    return AdcRegReadResult{.value=0, .error=AdcError::I2CError};
+bool ADS7138::init(TwoWire* i2c, uint8_t addr) {
+  _i2c_addr = addr;
+  _i2c = i2c;
+
+  uint8_t res;
+
+  if(!reg_read_single(ADC_SYSTEM_STATUS, res) || res == 0) {
+    return false; // Failed to contact chip or failed to read
   }
-  uint8_t ct = WIRE.requestFrom((int)address, 1, 1);
-  if(ct != 1){
-    return AdcRegReadResult{.value=0, .error=AdcError::I2CError};
+
+  // Set sequencing channels
+  uint8_t enable_byte = 0b11110111; // All channels but channel 3
+  if(!reg_write_single(ADC_AUTO_SEQ_CH_SEL, enable_byte)) {
+    return false;
   }
-  int value = WIRE.read();
-  return AdcRegReadResult{.value=value, .error=AdcError::NoError};
+
+  // Enable auto sequencing
+  enable_byte = 0b00010001; // Enable sequence, auto sequence
+  if(!reg_write_single(ADC_SEQUENCE_CFG, enable_byte)) {
+    return false;
+  }
+
+  return true;
 }
 
-static AdcError adc_reg_write(uint8_t address, uint8_t reg_address, uint8_t data) {
-  WIRE.beginTransmission(address);
-  WIRE.write(ADC_REG_WRITE);
-  WIRE.write(reg_address);
-  WIRE.write(data);
-  if(WIRE.endTransmission(true) != 0){
-    return AdcError::I2CError;
+void ADS7138::tick() {
+  uint8_t buf[16];
+  reg_read_block(ADC_CHANNEL_READ_START, 16, buf);
+
+  for(int i = 0; i < 8; i++) {
+    _ch_readings[i] = buf[i] + (buf[i+1] << 8);
   }
-  return AdcError::NoError;
 }
 
-bool adcSetOutput(ADCAddress pin){
-    if(pin.pin_id < 0 || pin.pin_id >= 8){
-        return false;
-    }
-
-    adc_reg_write(ADC_ADDR, ADC_MANUAL_CH_SEL, pin.pin_id);
-
+bool ADS7138::i2c_lock() {
+    xSemaphoreTake(i2c_mutex, portMAX_DELAY);
     return true;
 }
 
-AdcReadResult adcAnalogRead(ADCAddress pin){ 
-    if(!adcSetOutput(pin)){
-        return AdcReadResult{.value=0, .error=AdcError::InvalidPinError};
-    }
-
-    int ct = WIRE.requestFrom((int)ADC_ADDR, 2, 1);
-    if(ct != 2){
-        return AdcReadResult{.value=0, .error=AdcError::I2CError};
-    }
-    int high = WIRE.read();
-    int low = WIRE.read();
-    uint16_t value = (high << 8) + low;
-    return AdcReadResult{.value=value, .error=AdcError::NoError};
+void ADS7138::i2c_unlock(void) {
+    xSemaphoreGive(i2c_mutex);
 }
 
-bool ADS7138Init(){
-  AdcRegReadResult reg = adc_reg_read(ADC_ADDR, ADC_SYSTEM_STATUS);
-  if(reg.error != AdcError::NoError){
+bool ADS7138::reg_read_single(uint8_t addr, uint8_t& outval) {
+    i2c_lock();
+    _i2c->beginTransmission(_i2c_addr);
+    _i2c->write(ADC_REG_READ);
+    _i2c->write(addr);
+    if(WIRE.endTransmission(true) != 0){
+      i2c_unlock();
+      Serial.print("[ADS7138] Failed to read from addr 0x");
+      Serial.println(addr, HEX);
+      return false;
+    }
+
+    uint8_t ct = WIRE.requestFrom((int)_i2c_addr, 1, 1);
+    if(ct != 1){
+      i2c_unlock();
+      Serial.print("[ADS7138] Failed to read from addr 0x");
+      Serial.println(addr, HEX);
+      return false;
+    }
+
+    outval = WIRE.read();
+    i2c_unlock();
+    return true;
+}
+
+bool ADS7138::reg_write_single(uint8_t reg_address, uint8_t data) {
+  i2c_lock();
+  _i2c->beginTransmission(_i2c_addr);
+  _i2c->write(ADC_REG_WRITE);
+  _i2c->write(reg_address);
+  _i2c->write(data);
+  if(_i2c->endTransmission(true) != 0){
+    i2c_unlock();
+    Serial.print("[ADS7138] Failed to write to addr 0x");
+    Serial.println(reg_address, HEX);
     return false;
   }
-  return reg.value != 0;
+  i2c_unlock();
+  return true;
+}
+
+bool ADS7138::reg_read_block(uint8_t start_addr, size_t num_reg, uint8_t* out_buf) {
+    i2c_lock();
+    _i2c->beginTransmission(_i2c_addr);
+    _i2c->write(ADC_REG_READ_CONTINUOUS);
+    _i2c->write(start_addr);
+    if(WIRE.endTransmission(true) != 0){
+      i2c_unlock();
+      Serial.print("[ADS7138] Failed to read block from addr 0x");
+      Serial.print(start_addr, HEX);
+      Serial.print(" (Read size: ");
+      Serial.print(num_reg);
+      Serial.println(" B)");
+      return false;
+    }
+
+    uint8_t ct = WIRE.requestFrom((int)_i2c_addr, (int) num_reg, 1);
+    if(ct != num_reg){
+      i2c_unlock();
+      Serial.print("[ADS7138] Failed to read block from addr 0x");
+      Serial.print(start_addr, HEX);
+      Serial.print(" (Read size: ");
+      Serial.print(num_reg);
+      Serial.println(" B)");
+      return false;
+    }
+
+    for(size_t i = 0; i < num_reg; i++) {
+      out_buf[i] = WIRE.read();
+    }
+
+    i2c_unlock();
+    return true;
+}
+
+float ADS7138::read(uint8_t pin) {
+  uint16_t raw_value = _ch_readings[pin];
+  float abs_voltage = ((static_cast<float>(raw_value) / kADCRegisterWidth) * kADCVoltageReference) / kADCPinConversionFactors[pin];
+  return abs_voltage;
 }

--- a/MIDAS/lib/ADS7138Q1/ads7138-q1.cpp
+++ b/MIDAS/lib/ADS7138Q1/ads7138-q1.cpp
@@ -37,9 +37,6 @@ bool ADS7138::init(TwoWire* i2c, uint8_t addr) {
     return false; // Failed to contact chip or failed to read
   }
 
-  Serial.print("ADC RES ");
-  Serial.println(res, HEX);
-
   // Set sequencing channels
   uint8_t enable_byte = 0b11110111; // All channels but channel 3
   if(!reg_write_single(ADC_AUTO_SEQ_CH_SEL, enable_byte)) {

--- a/MIDAS/lib/ADS7138Q1/ads7138-q1.h
+++ b/MIDAS/lib/ADS7138Q1/ads7138-q1.h
@@ -1,23 +1,40 @@
 #pragma once
 
 #include<cstdint>
+#include <Wire.h>
 
-struct ADCAddress {
-    int pin_id;
+#define ADC_PYRO_VOLTAGE_CONVERSION (18.0 / (100.0 + 18.0))
+#define ADC_PBATT_VOLTAGE_CONVERSION (100.0 / (100.0 + 560.0))
+#define ADC_VBATT_VOLTAGE_CONVERSION (100.0 / (100.0 + 100.0))
+#define ADC_NULL_VOLTAGE_CONVERSION 0.0
+
+constexpr float kADCPinConversionFactors[8] = {
+    ADC_PYRO_VOLTAGE_CONVERSION,   // Pyro A
+    ADC_PYRO_VOLTAGE_CONVERSION,   // Pyro B
+    ADC_PBATT_VOLTAGE_CONVERSION,  // Pyro battery
+    ADC_NULL_VOLTAGE_CONVERSION,   // Nothing
+    ADC_PYRO_VOLTAGE_CONVERSION,   // Pyro C
+    ADC_PYRO_VOLTAGE_CONVERSION,   // Pyro D
+    ADC_NULL_VOLTAGE_CONVERSION,   // VCAP (unused)
+    ADC_VBATT_VOLTAGE_CONVERSION,  // Battery voltage
 };
 
-enum class AdcError {
-    NoError,
-    I2CError,
-    InvalidPinError,
+// actual driver for this chip lol
+class ADS7138 {
+    private:
+    uint16_t _ch_readings[8]; // Stored readings for all 8 pins
+    uint8_t _i2c_addr;
+    TwoWire* _i2c;
+
+    bool i2c_lock();
+    void i2c_unlock();
+    bool reg_read_single(uint8_t addr, uint8_t& outval);
+    bool reg_read_block(uint8_t start_addr, size_t num_reg, uint8_t* out_buf);
+    bool reg_write_single(uint8_t addr, uint8_t value);
+
+    public:
+    bool init(TwoWire* i2c, uint8_t addr);
+    bool set_outputs(uint8_t ch_mask);
+    void tick(); // Actually does does the channel reading
+    float read(uint8_t pin);
 };
-
-struct AdcReadResult {
-    uint16_t value;
-    AdcError error;
-};
-
-AdcReadResult adcAnalogRead(ADCAddress pin);
-bool ADS7138Init();
-
-bool adcSetOutput(ADCAddress pin);

--- a/MIDAS/lib/ADS7138Q1/ads7138-q1.h
+++ b/MIDAS/lib/ADS7138Q1/ads7138-q1.h
@@ -31,6 +31,7 @@ class ADS7138 {
     bool reg_read_single(uint8_t addr, uint8_t& outval);
     bool reg_read_block(uint8_t start_addr, size_t num_reg, uint8_t* out_buf);
     bool reg_write_single(uint8_t addr, uint8_t value);
+    bool reg_write_single_bitset(uint8_t addr, uint8_t setmask);
 
     public:
     bool init(TwoWire* i2c, uint8_t addr);

--- a/MIDAS/lib/TCAL9538/TCAL9538.cpp
+++ b/MIDAS/lib/TCAL9538/TCAL9538.cpp
@@ -61,32 +61,34 @@ static uint8_t pin_state[1] = {0xff};
 static uint8_t pin_config[1] = {0xff};
 
 GpioError gpioDigitalWrite(GpioAddress addr, int mode){
-
-
     if(!addr.is_valid) {
         return GpioError::InvalidPinError;
     }
 
     TwoWire& wire = tcal_get_wire_by_id(addr.gpio_id);
 
-    uint8_t current_state = pin_state[addr.gpio_id];
+    uint8_t old_state = pin_state[addr.gpio_id];
+    uint8_t new_state = old_state;
     if(mode == HIGH){
-        current_state |= (1 << addr.pin_id);
+        new_state |= (1 << addr.pin_id);
     } else if(mode == LOW){
-        current_state &= ~(1 << addr.pin_id);
+        new_state &= ~(1 << addr.pin_id);
     } else {
         return GpioError::InvalidModeError;
     }
 
+    // if no change skip the i2c write
+    if(new_state == old_state) {
+        return GpioError::NoError;
+    }
+
     wire.beginTransmission(addr.gpio_address);
     wire.write(REG_OUTPUT);
-    wire.write(current_state);
-    pin_state[addr.gpio_id] = current_state;
-    int err = 0;
-    err = wire.endTransmission(true);
-    if(err != 0){
+    wire.write(new_state);
+    if(wire.endTransmission(true) != 0){
         return GpioError::I2CError;
     }
+    pin_state[addr.gpio_id] = new_state;
     return GpioError::NoError;
 }
 

--- a/MIDAS/src/Queue.h
+++ b/MIDAS/src/Queue.h
@@ -43,8 +43,8 @@ public:
      */
     void send(T value) {
         if(xQueueSendToBack(queue, &value, 0) == errQUEUE_FULL){
-            Serial.print("FULL QUEUE");
-            Serial.println(pcTaskGetName(nullptr));
+            // Serial.print("FULL QUEUE");
+            // Serial.println(pcTaskGetName(nullptr));
         }
     }
 

--- a/MIDAS/src/b2b_interface.cpp
+++ b/MIDAS/src/b2b_interface.cpp
@@ -9,7 +9,7 @@ ErrorCode B2BInterface::init() {
 
 CameraData CameraB2B::read() {
     #ifdef B2B_I2C
-    Wire.requestFrom(0x69, 3);
+    Wire.requestFrom(0x69, 3, 1);
     uint8_t res1 = Wire.read();
     uint8_t res2 = Wire.read();
     uint8_t res3 = Wire.read();

--- a/MIDAS/src/errors.h
+++ b/MIDAS/src/errors.h
@@ -17,6 +17,7 @@ enum ErrorCode {
     GyroCouldNotBeInitialized = 8,
     PyroGPIOCouldNotBeInitialized = 9,
     GPSCouldNotBeInitialized = 10,
+    ADCFailedToInit = 11,
     RadioInitFailed = 12,
     RadioSetFrequencyFailed = 13,
     CannotConnectBNO = 14,

--- a/MIDAS/src/hal.h
+++ b/MIDAS/src/hal.h
@@ -70,3 +70,4 @@
  * Initialized in begin_systems() before threads start.
  */
 extern SemaphoreHandle_t spi_mutex;
+extern SemaphoreHandle_t i2c_mutex;

--- a/MIDAS/src/hardware/GPSSensor.cpp
+++ b/MIDAS/src/hardware/GPSSensor.cpp
@@ -1,4 +1,6 @@
 #include <Wire.h>
+#include <freertos/FreeRTOS.h>
+#include <freertos/semphr.h>
 
 #include <SparkFun_u-blox_GNSS_v3.h>
 
@@ -6,7 +8,27 @@
 #include "sensors.h"
 #include "sensor_data.h"
 
-SFE_UBLOX_GNSS ublox;
+// see systems.cpp
+extern SemaphoreHandle_t i2c_mutex;
+
+// override ublox for using the i2c mutex
+class MIDASUbloxGNSS : public SFE_UBLOX_GNSS {
+protected:
+    bool createLock(void) override {
+        return true;
+    }
+    bool lock(void) override {
+        xSemaphoreTake(i2c_mutex, portMAX_DELAY);
+        return true;
+    }
+    void unlock(void) override {
+        xSemaphoreGive(i2c_mutex);
+    }
+    void deleteLock(void) override {
+    }
+};
+
+MIDASUbloxGNSS ublox;
 
 /**
  * @brief Initializes GPS, returns NoError

--- a/MIDAS/src/hardware/GPSSensor.cpp
+++ b/MIDAS/src/hardware/GPSSensor.cpp
@@ -41,12 +41,9 @@ ErrorCode GPSSensor::init() {
     }
 
     ublox.setDynamicModel(DYN_MODEL_AIRBORNE4g);
-	ublox.setI2COutput(COM_TYPE_UBX | COM_TYPE_NMEA); //Set the I2C port to output both NMEA and UBX messages
-    // Set the measurment rate faster than one HZ if necessary
-    // ublox.setMeasurementRate(100);
-	ublox.saveConfigSelective(VAL_CFG_SUBSEC_IOPORT); //Save (only) the communications port settings to flash and BBR
-
-	//This will pipe all NMEA sentences to the serial port so we can see them
+    ublox.setI2COutput(COM_TYPE_UBX | COM_TYPE_NMEA);
+    ublox.setMeasurementRate(100);              // 10 Hz full nav
+    ublox.setAutoPVT(true);
 
     return ErrorCode::NoError;
 }

--- a/MIDAS/src/hardware/Pyro.cpp
+++ b/MIDAS/src/hardware/Pyro.cpp
@@ -45,9 +45,7 @@ ErrorCode Pyro::init() {
 }
 
 void Pyro::disarm_all_channels(PyroState& prev_state) {
-    gpioDigitalWrite(PYRO_GLOBAL_ARM_PIN, LOW); // For good measure
     for(int i = 0; i < MIDAS_NUM_PYROS; ++i) {
-        gpioDigitalWrite(PYRO_PINS[i], LOW); // For good measure
         prev_state.channel_firing[i] = false;
     }
     prev_state.is_global_armed = false;

--- a/MIDAS/src/hardware/Voltage.cpp
+++ b/MIDAS/src/hardware/Voltage.cpp
@@ -24,7 +24,7 @@ int read_board_pwr_monitor_register(int reg, int bytes) {
         Serial.println("I2C Error");
     }
 
-    Wire1.requestFrom(0x44, bytes);
+    Wire1.requestFrom(0x44, bytes, 1);
     int val = 0;
 
     for(int i = 0; i < bytes; i++){

--- a/MIDAS/src/hardware/Voltage.cpp
+++ b/MIDAS/src/hardware/Voltage.cpp
@@ -27,6 +27,8 @@ ErrorCode VoltageSensor::init() {
 Voltage VoltageSensor::read() {
     Voltage voltage;
 
+    ADC.tick();
+
     voltage.v_Bat = ADC.read(VBAT_SENSE);
     voltage.v_Pyro = ADC.read(PYRO_SENSE);
     voltage.continuity[0] = ADC.read(SENSE_A);

--- a/MIDAS/src/hardware/Voltage.cpp
+++ b/MIDAS/src/hardware/Voltage.cpp
@@ -3,38 +3,9 @@
 #include <ads7138-q1.h>
 #include <Wire.h>
 
-constexpr float VOLTAGE_DIVIDER = (5.0 / (5.0 + 20.0));
-constexpr float PYRO_VOLTAGE_DIVIDER = (18.0/(100.0+18.0));
-constexpr float PYRO_BATT_VOLTAGE_DIVIDER = (100.0/(100.0+560.0));
-constexpr float BATT_VOLTAGE_DIVIDER = (100.0/(100.0+100.0));
-constexpr float VOLTAGE_SCALE = 3.3;
-constexpr int VOLTAGE_REG_WIDTH = (1<<16);
+#define ADC_I2C_ADDR 0x14
 
-constexpr ADCAddress pinA = {SENSE_A};
-constexpr ADCAddress pinB = {SENSE_B};
-constexpr ADCAddress pinC = {SENSE_C};
-constexpr ADCAddress pinD = {SENSE_D};
-constexpr ADCAddress pinBat = {VBAT_SENSE};
-constexpr ADCAddress pinPyro = {PYRO_SENSE};
-
-int read_board_pwr_monitor_register(int reg, int bytes) {
-    Wire1.beginTransmission(0x44);
-    Wire1.write(reg);
-    if(Wire1.endTransmission()){
-        Serial.println("I2C Error");
-    }
-
-    Wire1.requestFrom(0x44, bytes, 1);
-    int val = 0;
-
-    for(int i = 0; i < bytes; i++){
-        int v = Wire1.read();
-        if(v == -1) Serial.println("I2C Read Error");
-        val = (val << 8) | v;
-    }
-
-    return val;
-}
+ADS7138 ADC;
 
 /**
  * @brief "Initializes" the voltage sensor. Since it reads directly from a pin without a library, there is no specific initialization.
@@ -42,6 +13,9 @@ int read_board_pwr_monitor_register(int reg, int bytes) {
  * @return Error Code, will always be NoError
 */
 ErrorCode VoltageSensor::init() {
+    if(!ADC.init(&Wire, ADC_I2C_ADDR)) {
+        return ErrorCode::ADCFailedToInit;
+    }
     return ErrorCode::NoError;
 }
 
@@ -53,47 +27,12 @@ ErrorCode VoltageSensor::init() {
 Voltage VoltageSensor::read() {
     Voltage voltage;
 
-    //Getting ADC values
-    AdcReadResult sensorA = adcAnalogRead(pinA);
-    AdcReadResult sensorB = adcAnalogRead(pinB);
-    AdcReadResult sensorC = adcAnalogRead(pinC);
-    AdcReadResult sensorD = adcAnalogRead(pinD);
-    AdcReadResult sensorBat = adcAnalogRead(pinBat);
-    AdcReadResult sensorPyro = adcAnalogRead(pinPyro);
-    
-    //Set output to pin A to avoid pyro battery voltage leaking into next reading
-    adcSetOutput(pinA); 
-
-    //Converts ADC value to voltage for each pin
-    if(sensorBat.error == AdcError::NoError){
-        float Bat_voltage = ((static_cast<float>(sensorBat.value) / VOLTAGE_REG_WIDTH) * VOLTAGE_SCALE) / BATT_VOLTAGE_DIVIDER; 
-        voltage.v_Bat = Bat_voltage;
-    }
-
-    if(sensorPyro.error == AdcError::NoError){
-        float Pyro_voltage = ((static_cast<float>(sensorPyro.value) / VOLTAGE_REG_WIDTH) * VOLTAGE_SCALE)/(PYRO_BATT_VOLTAGE_DIVIDER); //Accounting for voltage divider on MIDAS mini
-        voltage.v_Pyro = Pyro_voltage;
-    }
-
-    if(sensorA.error == AdcError::NoError){
-        float A_voltage = ((static_cast<float>(sensorA.value) / VOLTAGE_REG_WIDTH) * VOLTAGE_SCALE) / PYRO_VOLTAGE_DIVIDER;
-        voltage.continuity[0] = A_voltage;
-    }
-
-    if(sensorB.error == AdcError::NoError){
-        float B_voltage = ((static_cast<float>(sensorB.value) / VOLTAGE_REG_WIDTH) * VOLTAGE_SCALE) / PYRO_VOLTAGE_DIVIDER;
-        voltage.continuity[1] = B_voltage;
-    }
-
-    if(sensorC.error == AdcError::NoError){
-        float C_voltage = ((static_cast<float>(sensorC.value) / VOLTAGE_REG_WIDTH) * VOLTAGE_SCALE) / PYRO_VOLTAGE_DIVIDER;
-        voltage.continuity[2] = C_voltage;
-    }
-
-    if(sensorD.error == AdcError::NoError){
-        float D_voltage = ((static_cast<float>(sensorD.value) / VOLTAGE_REG_WIDTH) * VOLTAGE_SCALE) / PYRO_VOLTAGE_DIVIDER;
-        voltage.continuity[3] = D_voltage;
-    }
+    voltage.v_Bat = ADC.read(VBAT_SENSE);
+    voltage.v_Pyro = ADC.read(PYRO_SENSE);
+    voltage.continuity[0] = ADC.read(SENSE_A);
+    voltage.continuity[1] = ADC.read(SENSE_B);
+    voltage.continuity[2] = ADC.read(SENSE_C);
+    voltage.continuity[3] = ADC.read(SENSE_D);
 
     return voltage;
 }

--- a/MIDAS/src/midas_shell_commands.h
+++ b/MIDAS/src/midas_shell_commands.h
@@ -574,7 +574,18 @@ MCommandExecutionResult cmd_lfd(const MShellContext& ctx) {
     // <meta file content>
     // <bin file content>
 
-    if (ctx.argc != 2) { return MCommandExecutionResult::ERR_INVAL_ARGC; }
+    if (ctx.argc != 2 && ctx.argc != 3) {  }
+    bool stop_after_header_print = false;
+    if(ctx.argc == 3) {
+        if(!strcmp(ctx.argv[2], "--head")) {
+            stop_after_header_print = true;
+        } else {
+            return MCommandExecutionResult::ERR_INVAL_ARGUMENT;
+        }
+    } else if (ctx.argc != 2) {
+        return MCommandExecutionResult::ERR_INVAL_ARGC;
+    }
+
 
     String bin_path = "/" + String(ctx.argv[1]) + ".bin";
     String meta_path = "/" + String(ctx.argv[1]) + ".meta";
@@ -590,14 +601,34 @@ MCommandExecutionResult cmd_lfd(const MShellContext& ctx) {
         Serial.println("Failed to open .meta file!");
         return MCommandExecutionResult::ERR_FS_FAIL_OPEN;
     }
+
+    size_t size_ptr = LOG_FMT_VERSION; // We write multiple uint32_ts, so for serial.write to print it properly we need to store it
     
     // Start writing header
-    Serial.write("LAUNCH "); Serial.write(LOG_FMT_VERSION); Serial.write('\n');
+    Serial.write("LAUNCH "); Serial.write((uint8_t*)size_ptr, sizeof(size_t)); Serial.write('\n');
+
+    // File name
     Serial.write("FILE "); Serial.write(ctx.argv[1]); Serial.write('\n');
-    Serial.write("CHECKSUM "); Serial.write(LOG_CHECKSUM); Serial.write(" "); Serial.write(EEPROM_CHECKSUM); Serial.write('\n');
-    Serial.write("META "); Serial.write(meta_file.size()); Serial.write('\n');
-    Serial.write("BIN "); Serial.write(bin_file.size()); Serial.write('\n');
+    
+    // Log checksum
+    size_ptr = LOG_CHECKSUM;
+    Serial.write("CHECKSUM "); Serial.write((uint8_t*)size_ptr, sizeof(size_t)); Serial.write(" "); 
+    
+    // EEPROM checksum
+    size_ptr = EEPROM_CHECKSUM;
+    Serial.write((uint8_t*)size_ptr, sizeof(size_t)); Serial.write('\n');
+
+    // Meta file size
+    size_ptr = meta_file.size();
+    Serial.write("META "); Serial.write((uint8_t*)size_ptr, sizeof(size_t)); Serial.write('\n');
+
+    // Binary file size
+    size_ptr = bin_file.size();
+    Serial.write("BIN "); Serial.write((uint8_t*)size_ptr, sizeof(size_t)); Serial.write('\n');
+
     Serial.flush();
+
+    if(stop_after_header_print) { return MCommandExecutionResult::OK; }
 
     // Then dump meta and bin files
     while(meta_file.available()) {

--- a/MIDAS/src/midas_shell_commands.h
+++ b/MIDAS/src/midas_shell_commands.h
@@ -605,26 +605,26 @@ MCommandExecutionResult cmd_lfd(const MShellContext& ctx) {
     size_t size_ptr = LOG_FMT_VERSION; // We write multiple uint32_ts, so for serial.write to print it properly we need to store it
     
     // Start writing header
-    Serial.write("LAUNCH "); Serial.write((uint8_t*)size_ptr, sizeof(size_t)); Serial.write('\n');
+    Serial.write("LAUNCH "); Serial.write((uint8_t*)&size_ptr, sizeof(size_t)); Serial.write('\n');
 
     // File name
     Serial.write("FILE "); Serial.write(ctx.argv[1]); Serial.write('\n');
     
     // Log checksum
     size_ptr = LOG_CHECKSUM;
-    Serial.write("CHECKSUM "); Serial.write((uint8_t*)size_ptr, sizeof(size_t)); Serial.write(" "); 
+    Serial.write("CHECKSUM "); Serial.write((uint8_t*)&size_ptr, sizeof(size_t)); Serial.write(" "); 
     
     // EEPROM checksum
     size_ptr = EEPROM_CHECKSUM;
-    Serial.write((uint8_t*)size_ptr, sizeof(size_t)); Serial.write('\n');
+    Serial.write((uint8_t*)&size_ptr, sizeof(size_t)); Serial.write('\n');
 
     // Meta file size
     size_ptr = meta_file.size();
-    Serial.write("META "); Serial.write((uint8_t*)size_ptr, sizeof(size_t)); Serial.write('\n');
+    Serial.write("META "); Serial.write((uint8_t*)&size_ptr, sizeof(size_t)); Serial.write('\n');
 
     // Binary file size
     size_ptr = bin_file.size();
-    Serial.write("BIN "); Serial.write((uint8_t*)size_ptr, sizeof(size_t)); Serial.write('\n');
+    Serial.write("BIN "); Serial.write((uint8_t*)&size_ptr, sizeof(size_t)); Serial.write('\n');
 
     Serial.flush();
 

--- a/MIDAS/src/midas_shell_commands.h
+++ b/MIDAS/src/midas_shell_commands.h
@@ -732,7 +732,7 @@ MCommandExecutionResult m_sdfn(const MShellContext& ctx) {
     }
 
     if(ctx.argc == 2) {
-        uint16_t val = atoi(ctx.argv[2]);
+        int val = atoi(ctx.argv[1]);
         arg->eeprom.data.sd_file_num_last = val;
         arg->eeprom.commit();
         return MCommandExecutionResult::OK;

--- a/MIDAS/src/systems.cpp
+++ b/MIDAS/src/systems.cpp
@@ -209,7 +209,7 @@ DECLARE_THREAD(gps, RocketSystems *arg)
             arg->rocket_data.gps.update(reading);
         }
         // GPS waits internally
-        THREAD_SLEEP(1);
+        THREAD_SLEEP(25);
     }
 }
 

--- a/MIDAS/src/systems.cpp
+++ b/MIDAS/src/systems.cpp
@@ -257,11 +257,8 @@ DECLARE_THREAD(pyro, RocketSystems *arg)
 
 DECLARE_THREAD(voltage, RocketSystems* arg) {
     while (true) {
-        xSemaphoreTake(i2c_mutex, portMAX_DELAY);
         Voltage reading2 = arg->sensors.voltage.read();
-        xSemaphoreGive(i2c_mutex);
         arg->rocket_data.voltage.update(reading2);
-
         THREAD_SLEEP(100);
     }
 }

--- a/MIDAS/src/systems.cpp
+++ b/MIDAS/src/systems.cpp
@@ -202,11 +202,10 @@ DECLARE_THREAD(gps, RocketSystems *arg)
 {
     while (true)
     {
+        // GPS's internal operations have a xSemaphoreTake.
         if (arg->sensors.gps.valid())
         {
-            xSemaphoreTake(i2c_mutex, portMAX_DELAY);
             GPS reading = arg->sensors.gps.read();
-            xSemaphoreGive(i2c_mutex);
             arg->rocket_data.gps.update(reading);
         }
         // GPS waits internally

--- a/MIDAS/src/systems.cpp
+++ b/MIDAS/src/systems.cpp
@@ -7,7 +7,9 @@
 #include "midas_shell_commands.h"
 
 static StaticSemaphore_t spi_mutex_buffer;
+static StaticSemaphore_t i2c_mutex_buffer;
 SemaphoreHandle_t spi_mutex;
+SemaphoreHandle_t i2c_mutex;
 
 #define ENABLE_TELEM
 
@@ -202,7 +204,9 @@ DECLARE_THREAD(gps, RocketSystems *arg)
     {
         if (arg->sensors.gps.valid())
         {
+            xSemaphoreTake(i2c_mutex, portMAX_DELAY);
             GPS reading = arg->sensors.gps.read();
+            xSemaphoreGive(i2c_mutex);
             arg->rocket_data.gps.update(reading);
         }
         // GPS waits internally
@@ -238,10 +242,12 @@ DECLARE_THREAD(pyro, RocketSystems *arg)
         PyroState new_pyro_state = arg->sensors.pyro.tick(tick_data);
 
         // Actually update the pyro state!
+        xSemaphoreTake(i2c_mutex, portMAX_DELAY);
         gpioDigitalWrite(PYRO_GLOBAL_ARM_PIN, new_pyro_state.is_global_armed ? HIGH : LOW);
         for(int i = 0; i < MIDAS_NUM_PYROS; i++) {
             gpioDigitalWrite(PYRO_PINS[i], new_pyro_state.channel_firing[i] ? HIGH : LOW);
         }
+        xSemaphoreGive(i2c_mutex);
 
         arg->rocket_data.pyro.update(new_pyro_state);
         arg->led.update();
@@ -252,7 +258,9 @@ DECLARE_THREAD(pyro, RocketSystems *arg)
 
 DECLARE_THREAD(voltage, RocketSystems* arg) {
     while (true) {
+        xSemaphoreTake(i2c_mutex, portMAX_DELAY);
         Voltage reading2 = arg->sensors.voltage.read();
+        xSemaphoreGive(i2c_mutex);
         arg->rocket_data.voltage.update(reading2);
 
         THREAD_SLEEP(100);
@@ -706,6 +714,7 @@ DECLARE_THREAD(cam, RocketSystems *arg)
         }
 
         // Check if CAM specifically is on the I2C bus
+        xSemaphoreTake(i2c_mutex, portMAX_DELAY);
         Wire.beginTransmission(0x69);
         byte error = Wire.endTransmission();
 
@@ -721,6 +730,7 @@ DECLARE_THREAD(cam, RocketSystems *arg)
             arg->rocket_data.cam_data.update(new_cam_data);
             THREAD_SLEEP(1800);
         }
+        xSemaphoreGive(i2c_mutex);
 
         THREAD_SLEEP(200);
     }
@@ -910,6 +920,7 @@ ErrorCode init_systems(RocketSystems& systems) {
 {
     Serial.println("Starting Systems...");
     spi_mutex = xSemaphoreCreateMutexStatic(&spi_mutex_buffer);
+    i2c_mutex = xSemaphoreCreateMutexStatic(&i2c_mutex_buffer);
 
 
     ErrorCode init_error_code = init_systems(*config);
@@ -933,12 +944,12 @@ ErrorCode init_systems(RocketSystems& systems) {
     START_THREAD(voltage, SENSOR_CORE, config, 9);
     START_THREAD(pyro, SENSOR_CORE, config, 14);
     START_THREAD(magnetometer, SENSOR_CORE, config, 11);
-    START_THREAD(cam, SENSOR_CORE, config, 16);
+    START_THREAD(cam, SENSOR_CORE, config, 5);
     START_THREAD(kalman, SENSOR_CORE, config, 7);
     START_THREAD(fsm, SENSOR_CORE, config, 8);
     START_THREAD(buzzer, SENSOR_CORE, config, 6);
     START_THREAD(angularkalman, SENSOR_CORE, config, 7);
-    START_THREAD(shell, DATA_CORE, config, 5);
+    START_THREAD(shell, DATA_CORE, config, 4);
 
     #ifdef ENABLE_TELEM
     START_THREAD(telemetry, SENSOR_CORE, config, 15);

--- a/MIDAS/src/telemetry.cpp
+++ b/MIDAS/src/telemetry.cpp
@@ -156,7 +156,7 @@ TelemetryPacket Telemetry::makePacket(RocketData& data, const MIDASEEPROM& eepro
     // 00000 | 000
     // SATC  | FT
     packet.gpsfix_satcount |= (gps.fix_type & 0x07);
-    packet.gpsfix_satcount |= (gps.sats_in_view & 0x1F) << 5;
+    packet.gpsfix_satcount |= (gps.sats_in_view & 0x1F) << 3;
 
     packet.serial = eeprom.serial;
 

--- a/ground/src/feather_duo/Packet.cpp
+++ b/ground/src/feather_duo/Packet.cpp
@@ -49,8 +49,8 @@ FullTelemetryData DecodePacket(const TelemetryPacket& packet, float frequency) {
 
     // Other data
     data.battery_voltage = convert_range(packet.batt_volt, MAX_TELEM_VOLTAGE_V);
-    data.gps_fixtype = packet.gpsfix_satcount >> 1 & 0b0111;
-    data.sat_count = (packet.gpsfix_satcount >> 5) & 0x1F;
+    data.gps_fixtype = packet.gpsfix_satcount & 0b0111;
+    data.sat_count = (packet.gpsfix_satcount >> 3) & 0x1F;
 
     // Serial number
     data.serial_no = packet.serial;


### PR DESCRIPTION
Uses the PVT cache instead of tight I2C polling, and sets the output rate to 10hz (instead of 1hz).